### PR TITLE
[feat]채팅방 목록 조회 기능 구현

### DIFF
--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/chatting/ChattingControllor.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/chatting/ChattingControllor.java
@@ -3,11 +3,15 @@ package org.prgrms.devconnect.api.controller.chatting;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.prgrms.devconnect.api.controller.chatting.dto.request.ChatRoomRequest;
+import org.prgrms.devconnect.api.controller.chatting.dto.response.ChatRoomListResponse;
 import org.prgrms.devconnect.api.controller.chatting.dto.response.ChatRoomResponse;
 import org.prgrms.devconnect.api.service.chatting.ChattingCommandService;
+import org.prgrms.devconnect.api.service.chatting.ChattingQueryService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,17 +19,27 @@ import org.springframework.web.bind.annotation.*;
 public class ChattingControllor {
 
   private final ChattingCommandService chattingCommandService;
+  private final ChattingQueryService chattingQueryService;
 
-  @PostMapping("/{memberId}")
+  @PostMapping("/member/{memberId}")
   public ResponseEntity<ChatRoomResponse> createChatting(@PathVariable("memberId") Long memberId,
                                                          @RequestBody @Valid ChatRoomRequest request){
     Long chatroomId = chattingCommandService.createNewChatting(memberId, request.receiverId());
     return ResponseEntity.status(HttpStatus.OK).body(new ChatRoomResponse(chatroomId));
   }
 
+  @GetMapping("/member/{memberId}")
+  public ResponseEntity<List<ChatRoomListResponse>> createChatting(@PathVariable("memberId") Long memberId){
+    List<ChatRoomListResponse> allActivateChattingsByMemberId = chattingQueryService.findAllActivateChattingsByMemberId(memberId);
+    return ResponseEntity.status(HttpStatus.OK).body(allActivateChattingsByMemberId);
+  }
+
+
+
   @PutMapping("/{chatroomId}")
   public ResponseEntity<Void> closeChattingRoom(@PathVariable("chatroomId") Long chatroomId){
     chattingCommandService.closeChattingRoom(chatroomId);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
+
 }

--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/chatting/dto/response/ChatRoomListResponse.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/chatting/dto/response/ChatRoomListResponse.java
@@ -1,0 +1,13 @@
+package org.prgrms.devconnect.api.controller.chatting.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.prgrms.devconnect.domain.define.chatting.entity.constant.ChattingRoomStatus;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ChatRoomListResponse(
+        Long memberId,
+        Long roomId,
+        ChattingRoomStatus status
+) {
+}

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/chatting/ChattingCommandService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/chatting/ChattingCommandService.java
@@ -50,6 +50,7 @@ public class ChattingCommandService {
     chatParticipationRepository.save(senderChatPart);
     chatParticipationRepository.save(receiverChatPart);
 
+    //roomId 반환
     return chattingRoom.getRoomId();
   }
 

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/chatting/ChattingQueryService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/chatting/ChattingQueryService.java
@@ -1,0 +1,22 @@
+package org.prgrms.devconnect.api.service.chatting;
+
+import lombok.RequiredArgsConstructor;
+import org.prgrms.devconnect.api.controller.chatting.dto.response.ChatRoomListResponse;
+import org.prgrms.devconnect.domain.define.chatting.repository.ChatParticipationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChattingQueryService {
+
+  private final ChatParticipationRepository chatParticipationRepository;
+
+  public List<ChatRoomListResponse> findAllActivateChattingsByMemberId(Long memberId){
+    List<ChatRoomListResponse> results = chatParticipationRepository.findByMemberIdAndStatusIsActive(memberId);
+    return results;
+  }
+}

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/chatting/repository/ChatParticipationRepository.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/chatting/repository/ChatParticipationRepository.java
@@ -2,12 +2,14 @@ package org.prgrms.devconnect.domain.define.chatting.repository;
 
 
 import org.prgrms.devconnect.domain.define.chatting.entity.ChatParticipation;
+import org.prgrms.devconnect.domain.define.chatting.repository.custom.ChatPartRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface ChatParticipationRepository extends JpaRepository<ChatParticipation, Long> {
+public interface ChatParticipationRepository extends JpaRepository<ChatParticipation, Long>, ChatPartRepositoryCustom {
   List<ChatParticipation> findAllByChattingRoom_RoomId(Long roomId);
+
 }

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/chatting/repository/custom/ChatPartRepositoryCustom.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/chatting/repository/custom/ChatPartRepositoryCustom.java
@@ -1,0 +1,10 @@
+package org.prgrms.devconnect.domain.define.chatting.repository.custom;
+
+import org.prgrms.devconnect.api.controller.chatting.dto.response.ChatRoomListResponse;
+
+import java.util.List;
+
+public interface ChatPartRepositoryCustom {
+
+  List<ChatRoomListResponse> findByMemberIdAndStatusIsActive(Long memberId);
+}

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/chatting/repository/custom/ChatPartRepositoryCustomImpl.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/chatting/repository/custom/ChatPartRepositoryCustomImpl.java
@@ -1,0 +1,33 @@
+package org.prgrms.devconnect.domain.define.chatting.repository.custom;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.prgrms.devconnect.api.controller.chatting.dto.response.ChatRoomListResponse;
+import org.prgrms.devconnect.domain.define.chatting.entity.QChatParticipation;
+import org.prgrms.devconnect.domain.define.chatting.entity.QChattingRoom;
+import org.prgrms.devconnect.domain.define.chatting.entity.constant.ChattingRoomStatus;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class ChatPartRepositoryCustomImpl implements ChatPartRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+  @Override
+  public List<ChatRoomListResponse> findByMemberIdAndStatusIsActive(Long memberId) {
+    QChatParticipation chatpart = QChatParticipation.chatParticipation;
+    QChattingRoom chattingRoom = QChattingRoom.chattingRoom;
+
+    return queryFactory.select(Projections.constructor(
+                    ChatRoomListResponse.class ,
+                    chatpart.member.memberId,
+                    chattingRoom.roomId,
+                    chattingRoom.status
+            ))
+            .from(chatpart)
+            .join(chatpart.chattingRoom, chattingRoom)
+            .where(chatpart.member.memberId.eq(memberId).and(chattingRoom.status.eq(ChattingRoomStatus.ACTIVE)))
+            .fetch();
+  }
+}

--- a/backend/src/test/java/org/prgrms/devconnect/domain/define/chatting/ChattingServiceTest.java
+++ b/backend/src/test/java/org/prgrms/devconnect/domain/define/chatting/ChattingServiceTest.java
@@ -3,7 +3,6 @@ package org.prgrms.devconnect.domain.define.chatting;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.prgrms.devconnect.api.controller.chatting.dto.response.ChatRoomListResponse;
 import org.prgrms.devconnect.api.service.chatting.ChattingCommandService;
 import org.prgrms.devconnect.api.service.chatting.ChattingQueryService;
@@ -47,9 +46,6 @@ public class ChattingServiceTest {
   @Autowired
   private TechStackRepository techStackRepository;
 
-
-
-  private ChattingRoom chattingRoom;
   @BeforeEach
   void initData() throws Exception {
     TechStack techStack = TechStack.builder()
@@ -98,10 +94,6 @@ public class ChattingServiceTest {
 
     memberRepository.save(member1);
     memberRepository.save(member2);
-
-    // 테스트를 위한 채팅방 생성
-    chattingRoom = new ChattingRoom(ChattingRoomStatus.ACTIVE);
-    chattingRoomRepository.save(chattingRoom);
   }
 
   @Test
@@ -122,6 +114,9 @@ public class ChattingServiceTest {
   @DisplayName("채팅방 비활성화 테스트")
   void 채팅방_비활성화() throws Exception {
     // given
+    // 테스트를 위한 채팅방 생성
+    ChattingRoom chattingRoom = new ChattingRoom(ChattingRoomStatus.ACTIVE);
+    chattingRoomRepository.save(chattingRoom);
     Long roomId = chattingRoom.getRoomId();
 
     // when

--- a/backend/src/test/java/org/prgrms/devconnect/domain/define/chatting/ChattingServiceTest.java
+++ b/backend/src/test/java/org/prgrms/devconnect/domain/define/chatting/ChattingServiceTest.java
@@ -1,14 +1,12 @@
-package org.prgrms.devconnect.chatting;
+package org.prgrms.devconnect.domain.define.chatting;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.prgrms.devconnect.api.controller.chatting.dto.response.ChatRoomListResponse;
 import org.prgrms.devconnect.api.service.chatting.ChattingCommandService;
-import org.prgrms.devconnect.api.service.techstack.TechStackQueryService;
+import org.prgrms.devconnect.api.service.chatting.ChattingQueryService;
 import org.prgrms.devconnect.domain.define.chatting.entity.ChatParticipation;
 import org.prgrms.devconnect.domain.define.chatting.entity.ChattingRoom;
 import org.prgrms.devconnect.domain.define.chatting.entity.constant.ChattingRoomStatus;
@@ -37,13 +35,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class ChattingServiceTest {
 
   @Autowired
-  private ChattingCommandService chattingService;
+  private ChattingCommandService chattingCommandService;
+  @Autowired
+  private ChattingQueryService chattingQueryService;
+  @Autowired
+  private ChattingRoomRepository chattingRoomRepository;
   @Autowired
   private MemberRepository memberRepository;
   @Autowired
   private ChatParticipationRepository chatParticipationRepository;
-  @Autowired
-  private ChattingRoomRepository chattingRoomRepository;
   @Autowired
   private TechStackRepository techStackRepository;
 
@@ -81,6 +81,7 @@ public class ChattingServiceTest {
             .blogLink("blogLink")
             .githubLink("githubLink")
             .interest(Interest.JOBPOST)
+            .memberTechStacks(list1)
             .build();
     Member member2 = Member.builder()
             .email("example@naver.com")
@@ -92,6 +93,7 @@ public class ChattingServiceTest {
             .blogLink("blogLink2")
             .githubLink("githubLink2")
             .interest(Interest.STUDY)
+            .memberTechStacks(list2)
             .build();
 
     memberRepository.save(member1);
@@ -109,13 +111,7 @@ public class ChattingServiceTest {
     Member sender = results.get(0);
     Member receiver = results.get(0);
 
-    Long senderChatpartId = chattingService.createNewChatting(sender.getMemberId(), receiver.getMemberId());
-    assertNotNull(senderChatpartId, "채팅 참여 ID는 null이 아니어야 합니다.");
-
-    ChatParticipation result = chatParticipationRepository.findById(senderChatpartId).orElseThrow();
-    assertNotNull(result, "채팅 참여 객체가 존재해야 합니다.");
-
-    Long roomId = result.getChattingRoom().getRoomId();
+    Long roomId = chattingCommandService.createNewChatting(sender.getMemberId(), receiver.getMemberId());
     assertNotNull(roomId, "채팅방 ID는 null이 아니어야 합니다.");
 
     List<ChatParticipation> allByChattingRoomRoomId = chatParticipationRepository.findAllByChattingRoom_RoomId(roomId);
@@ -129,10 +125,39 @@ public class ChattingServiceTest {
     Long roomId = chattingRoom.getRoomId();
 
     // when
-    chattingService.closeChattingRoom(roomId);
+    chattingCommandService.closeChattingRoom(roomId);
 
     // then
     ChattingRoom updatedRoom = chattingRoomRepository.findById(roomId).orElseThrow();
     assertEquals(ChattingRoomStatus.INACTIVE, updatedRoom.getStatus(), "채팅방 상태는 INACTIVE여야 합니다.");
+  }
+
+  @Test
+  @DisplayName("사용자 ID로 채팅방 조회")
+  void 사용자_채팅방_전체조회() throws Exception {
+      //given
+    List<Member> results = memberRepository.findAll();
+    Member sender = results.get(0);
+    Member receiver = results.get(1);
+
+    Long chattingRoomId1 = chattingCommandService.createNewChatting(sender.getMemberId(), receiver.getMemberId());
+    Long chattingRoomId2 = chattingCommandService.createNewChatting(sender.getMemberId(), receiver.getMemberId());
+
+    //when
+    List<ChatRoomListResponse> allActivateChattingsByMemberId = chattingQueryService.findAllActivateChattingsByMemberId(sender.getMemberId());
+
+    //then
+    assertEquals(2, allActivateChattingsByMemberId.size(), "채팅방 개수는 2개여야 합니다.");
+
+    // 2. 리스트 내 각 ChatRoomListResponse의 memberId가 sender의 memberId와 일치하는지 확인
+    for (ChatRoomListResponse response : allActivateChattingsByMemberId) {
+      System.out.println(response);
+      assertEquals(sender.getMemberId(), response.memberId(), "채팅방의 memberId는 sender의 memberId와 일치해야 합니다.");
+    }
+
+    // 3. 상태가 ACTIVE인지 확인
+    for (ChatRoomListResponse response : allActivateChattingsByMemberId) {
+      assertEquals(ChattingRoomStatus.ACTIVE, response.status(), "채팅방 상태는 ACTIVE여야 합니다.");
+    }
   }
 }

--- a/backend/src/test/java/org/prgrms/devconnect/domain/define/chatting/entity/ChattingRoomTest.java
+++ b/backend/src/test/java/org/prgrms/devconnect/domain/define/chatting/entity/ChattingRoomTest.java
@@ -1,4 +1,4 @@
-package org.prgrms.devconnect.chatting.entity;
+package org.prgrms.devconnect.domain.define.chatting.entity;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #20 

## 📌 과제 설명 
> 사용자 ID를 이용하여 활성화된 채팅방 ID들을 가져오는 API 구현

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 요구사항 정의서 [채팅방 목록 조회](https://www.notion.so/Connect-01-08e2b6e039db477d88054d10b2222e28?pvs=4)
- API 명세서 [특정 사용자와 연관된 채팅 조회](https://www.notion.so/2ce106b0973d4bccbdb7d763a388c0db?pvs=4)

<!-- ## ✅ 피드백 반영사항  지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
