### PR TITLE
[feat] 관심 게시글 리스트 조회

### DIFF
--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/board/dto/request/BoardCreateRequestDto.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/board/dto/request/BoardCreateRequestDto.java
@@ -6,8 +6,11 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import org.prgrms.devconnect.domain.define.board.entity.Board;
 import org.prgrms.devconnect.domain.define.board.entity.BoardTechStackMapping;
+import org.prgrms.devconnect.domain.define.board.entity.constant.BoardCategory;
+import org.prgrms.devconnect.domain.define.board.entity.constant.ProgressWay;
 import org.prgrms.devconnect.domain.define.jobpost.entity.JobPost;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 
@@ -15,6 +18,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Builder
 public record BoardCreateRequestDto(
         @NotNull(message = "회원 ID는 필수입니다.")
         Long memberId,
@@ -27,14 +31,14 @@ public record BoardCreateRequestDto(
         @NotBlank(message = "내용은 필수입니다.")
         String content,
 
-        @NotBlank(message = "카테고리는 필수입니다.")
-        String category,
+        @NotNull(message = "카테고리는 필수입니다.")
+        BoardCategory category,
 
         @NotNull(message = "모집 인원은 필수입니다.")
         int recruitNum,
 
-        @NotBlank(message = "진행 방식은 필수입니다.")
-        String progressWay,
+        @NotNull(message = "진행 방식은 필수입니다.")
+        ProgressWay progressWay,
 
         @NotBlank(message = "진행 기간은 필수입니다.")
         String progressPeriod,

--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/board/dto/request/BoardUpdateRequestDto.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/board/dto/request/BoardUpdateRequestDto.java
@@ -5,7 +5,11 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
+import lombok.Builder;
+import org.prgrms.devconnect.domain.define.board.entity.constant.BoardCategory;
+import org.prgrms.devconnect.domain.define.board.entity.constant.ProgressWay;
 
+@Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record BoardUpdateRequestDto(
         @NotBlank(message = "제목은 필수입니다.")
@@ -14,14 +18,14 @@ public record BoardUpdateRequestDto(
         @NotBlank(message = "내용은 필수입니다.")
         String content,
 
-        @NotBlank(message = "카테고리는 필수입니다.")
-        String category,
+        @NotNull(message = "카테고리는 필수입니다.")
+        BoardCategory category,
 
         @NotNull(message = "모집 인원은 필수입니다.")
         int recruitNum,
 
-        @NotBlank(message = "진행 방식은 필수입니다.")
-        String progressWay,
+        @NotNull(message = "진행 방식은 필수입니다.")
+        ProgressWay progressWay,
 
         @NotBlank(message = "진행 기간은 필수입니다.")
         String progressPeriod,

--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/board/dto/response/BoardInfoResponseDto.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/board/dto/response/BoardInfoResponseDto.java
@@ -1,0 +1,35 @@
+package org.prgrms.devconnect.api.controller.board.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import org.prgrms.devconnect.domain.define.board.entity.Board;
+import org.prgrms.devconnect.domain.define.board.entity.constant.BoardCategory;
+import org.prgrms.devconnect.domain.define.board.entity.constant.ProgressWay;
+
+@Builder
+public record BoardInfoResponseDto(
+    Long boardId,
+    String title,
+    BoardCategory category,
+    ProgressWay progressWay,
+    LocalDateTime endDate,
+    int views,
+    int likes,
+    String author,
+    Long authorId
+) {
+
+  public static BoardInfoResponseDto from(Board board) {
+    return BoardInfoResponseDto.builder()
+        .boardId(board.getBoardId())
+        .title(board.getTitle())
+        .category(board.getCategory())
+        .progressWay(board.getProgressWay())
+        .endDate(board.getEndDate())
+        .views(board.getViews())
+        .likes(board.getLikes())
+        .author(board.getMember().getNickname())
+        .authorId(board.getMember().getMemberId())
+        .build();
+  }
+}

--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/interest/InterestController.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/interest/InterestController.java
@@ -1,0 +1,26 @@
+package org.prgrms.devconnect.api.controller.interest;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.prgrms.devconnect.api.controller.board.dto.response.BoardInfoResponseDto;
+import org.prgrms.devconnect.api.service.interest.InterestQueryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/interests")
+public class InterestController {
+
+  private final InterestQueryService interestQueryService;
+
+  @GetMapping("/{memberId}")
+  public ResponseEntity<List<BoardInfoResponseDto>> getInterestBoards(@PathVariable Long memberId) {
+    List<BoardInfoResponseDto> interestBoards = interestQueryService.getInterestBoards(memberId);
+    return ResponseEntity.ok(interestBoards);
+  }
+}

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestQueryService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestQueryService.java
@@ -21,7 +21,7 @@ public class InterestQueryService {
 
   public List<BoardInfoResponseDto> getInterestBoards(Long memberId) {
     Member member = memberQueryService.getMemberByIdOrThrow(memberId);
-    List<FavoriteBoard> favoriteBoards = favoriteBoardRepository.findAllByMemberIdWithBoard(
+    List<FavoriteBoard> favoriteBoards = favoriteBoardRepository.findAllByMemberWithBoard(
         member);
 
     return favoriteBoards.stream().map(FavoriteBoard::getBoard)

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestQueryService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestQueryService.java
@@ -1,0 +1,31 @@
+package org.prgrms.devconnect.api.service.interest;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.prgrms.devconnect.api.controller.board.dto.response.BoardInfoResponseDto;
+import org.prgrms.devconnect.api.service.member.MemberQueryService;
+import org.prgrms.devconnect.domain.define.member.entity.Member;
+import org.prgrms.devconnect.domain.define.member.entity.favoriteboard.FavoriteBoard;
+import org.prgrms.devconnect.domain.define.member.repository.FavoriteBoardRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InterestQueryService {
+
+  private final FavoriteBoardRepository favoriteBoardRepository;
+  private final MemberQueryService memberQueryService;
+
+  public List<BoardInfoResponseDto> getInterestBoards(Long memberId) {
+    Member member = memberQueryService.getMemberByIdOrThrow(memberId);
+    List<FavoriteBoard> favoriteBoards = favoriteBoardRepository.findAllByMemberIdWithBoard(
+        member);
+
+    return favoriteBoards.stream().map(FavoriteBoard::getBoard)
+        .map(BoardInfoResponseDto::from)
+        .collect(Collectors.toList());
+  }
+}

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/board/entity/Board.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/board/entity/Board.java
@@ -43,12 +43,14 @@ public class Board extends Timestamp {
   @Column(name = "content", columnDefinition = "TEXT")
   private String content;
 
+  @Enumerated(value = EnumType.STRING)
   @Column(name = "category", length = 200)
   private BoardCategory category;
 
   @Column(name = "recruit_num")
   private int recruitNum;
 
+  @Enumerated(value = EnumType.STRING)
   @Column(name = "progress_way", length = 50)
   private ProgressWay progressWay;
 

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/board/entity/Board.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/board/entity/Board.java
@@ -10,8 +10,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.prgrms.devconnect.api.controller.board.dto.request.BoardUpdateRequestDto;
+import org.prgrms.devconnect.domain.define.board.entity.constant.BoardCategory;
 import org.prgrms.devconnect.domain.define.board.entity.constant.BoardStatus;
 import org.prgrms.devconnect.domain.define.Timestamp;
+import org.prgrms.devconnect.domain.define.board.entity.constant.ProgressWay;
 import org.prgrms.devconnect.domain.define.jobpost.entity.JobPost;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 import org.prgrms.devconnect.domain.define.techstack.entity.TechStack;
@@ -42,13 +44,13 @@ public class Board extends Timestamp {
   private String content;
 
   @Column(name = "category", length = 200)
-  private String category;
+  private BoardCategory category;
 
   @Column(name = "recruit_num")
   private int recruitNum;
 
   @Column(name = "progress_way", length = 50)
-  private String progressWay;
+  private ProgressWay progressWay;
 
   @Column(name = "progress_period", length = 50)
   private String progressPeriod;
@@ -80,8 +82,8 @@ public class Board extends Timestamp {
 
   //  Board 생성자
   @Builder
-  public Board(Member member, JobPost jobPost, String title, String content, String category,
-               int recruitNum, String progressWay, String progressPeriod, LocalDateTime endDate,
+  public Board(Member member, JobPost jobPost, String title, String content, BoardCategory category,
+               int recruitNum, ProgressWay progressWay, String progressPeriod, LocalDateTime endDate,
                List<BoardTechStackMapping> boardTechStacks) {
     this.member = member;
     this.jobPost = jobPost;

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/board/entity/constant/BoardCategory.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/board/entity/constant/BoardCategory.java
@@ -1,0 +1,14 @@
+package org.prgrms.devconnect.domain.define.board.entity.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BoardCategory {
+
+  STUDY("스터디"),
+  TEAM_PROJECT("팀 프로젝트");
+
+  private final String text;
+}

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/board/entity/constant/ProgressWay.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/board/entity/constant/ProgressWay.java
@@ -1,0 +1,15 @@
+package org.prgrms.devconnect.domain.define.board.entity.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ProgressWay {
+
+  ONLINE("온라인"),
+  OFFLINE("오프라인"),
+  HYBRID("온/오프라인");
+
+  private final String text;
+}

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/member/repository/FavoriteBoardRepository.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/member/repository/FavoriteBoardRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 public interface FavoriteBoardRepository extends JpaRepository<FavoriteBoard, Long> {
 
   @Query("SELECT fb FROM FavoriteBoard fb left join fetch fb.board WHERE fb.member = :member")
-  List<FavoriteBoard> findAllByMemberIdWithBoard(Member member);
+  List<FavoriteBoard> findAllByMemberWithBoard(Member member);
 
 }
 

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/member/repository/FavoriteBoardRepository.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/member/repository/FavoriteBoardRepository.java
@@ -1,0 +1,15 @@
+package org.prgrms.devconnect.domain.define.member.repository;
+
+import java.util.List;
+import org.prgrms.devconnect.domain.define.member.entity.Member;
+import org.prgrms.devconnect.domain.define.member.entity.favoriteboard.FavoriteBoard;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface FavoriteBoardRepository extends JpaRepository<FavoriteBoard, Long> {
+
+  @Query("SELECT fb FROM FavoriteBoard fb left join fetch fb.board WHERE fb.member = :member")
+  List<FavoriteBoard> findAllByMemberIdWithBoard(Member member);
+
+}
+

--- a/backend/src/test/java/org/prgrms/devconnect/domain/define/fixture/BoardFixture.java
+++ b/backend/src/test/java/org/prgrms/devconnect/domain/define/fixture/BoardFixture.java
@@ -1,0 +1,74 @@
+package org.prgrms.devconnect.domain.define.fixture;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.prgrms.devconnect.api.controller.board.dto.request.BoardCreateRequestDto;
+import org.prgrms.devconnect.api.controller.board.dto.request.BoardTechStackRequestDto;
+import org.prgrms.devconnect.api.controller.board.dto.request.BoardUpdateRequestDto;
+import org.prgrms.devconnect.domain.define.board.entity.Board;
+import org.prgrms.devconnect.domain.define.board.entity.constant.BoardCategory;
+import org.prgrms.devconnect.domain.define.board.entity.constant.ProgressWay;
+import org.prgrms.devconnect.domain.define.member.entity.Member;
+
+public class BoardFixture {
+
+  public static Board createBoard(Member member) {
+    return Board.builder()
+        .member(member)
+        .jobPost(null)
+        .title("Spring 스터디 모집합니다.")
+        .content("SpringBoot, JPA, JWT, Security까지 패키지로 공부할 사람 구해요")
+        .category(BoardCategory.STUDY)
+        .recruitNum(5)
+        .progressWay(ProgressWay.ONLINE)
+        .progressPeriod("3개월")
+        .endDate(LocalDateTime.now())
+        .boardTechStacks(List.of())
+        .build();
+  }
+
+  // BoardCreateRequestDto
+  public static BoardCreateRequestDto createBoardCreateRequestDto(Long memberId, String title) {
+    return BoardCreateRequestDto.builder()
+        .memberId(memberId)
+        .jobPostId(null)
+        .title(title)
+        .content("SpringBoot, JPA, JWT, Security까지 패키지로 공부할 사람 구해요")
+        .category(BoardCategory.STUDY)
+        .recruitNum(5)
+        .progressWay(ProgressWay.ONLINE)
+        .progressPeriod("5개월")
+        .endDate(LocalDateTime.now())
+        .techStackRequests(List.of())
+        .build();
+  }
+
+  public static BoardCreateRequestDto createBoardCreateRequestDto(Long memberId, String title,
+      List<BoardTechStackRequestDto> techStackRequestDtos) {
+    return BoardCreateRequestDto.builder()
+        .memberId(memberId)
+        .jobPostId(null)
+        .title(title)
+        .content("SpringBoot, JPA, JWT, Security까지 패키지로 공부할 사람 구해요")
+        .category(BoardCategory.STUDY)
+        .recruitNum(5)
+        .progressWay(ProgressWay.ONLINE)
+        .progressPeriod("5개월")
+        .endDate(LocalDateTime.now())
+        .techStackRequests(techStackRequestDtos)
+        .build();
+  }
+
+  //BoardUpdateRequestDto
+  public static BoardUpdateRequestDto createBoardUpdateRequestDto(String title, String content) {
+    return BoardUpdateRequestDto.builder()
+        .title(title)
+        .content(content)
+        .category(BoardCategory.STUDY)
+        .recruitNum(5)
+        .progressWay(ProgressWay.ONLINE)
+        .progressPeriod("5개월")
+        .endDate(LocalDateTime.now())
+        .build();
+  }
+}


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #55 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 관심 게시글 리스트 조회

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 멤버 아이디로 관심 게시글 리스트를 조회할 수 있다.
- Board 엔티티의 필드 관련 수정이 있습니다. (중요!!!!!!) @InaJeong73 
  -  `String category`, `String progressWay` -> `BoardCategory category` `ProgressWay progressWay` 으로 변경
    - 변경에 따른 관련 Dto, 관련 테스트 수정
      - `MemberServiceTest` 테스트 코드 통과하도록 수정
  
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
