### PR TITLE
댓글 조회 기능 구현

### DIFF
--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/comment/CommentController.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/comment/CommentController.java
@@ -12,6 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import static org.springframework.http.HttpStatus.OK;
+
 
 @RestController
 @RequestMapping("/api/v1/comments")
@@ -28,7 +30,7 @@ public class CommentController {
 
   @GetMapping("/{boardId}")
   public ResponseEntity<Page<CommentResponseDto>> getComments(@PathVariable Long boardId, Pageable pageable) {
-    Page<CommentResponseDto>comments= commentCommandService.getCommentsByBoardId(boardId,pageable);
-    return ResponseEntity.ok(comments);
+    Page<CommentResponseDto>comments= commentQueryService.getCommentsByBoardId(boardId,pageable);
+    return ResponseEntity.status(OK).body(comments);
   }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/comment/CommentController.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/comment/CommentController.java
@@ -2,15 +2,16 @@ package org.prgrms.devconnect.api.controller.comment;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.prgrms.devconnect.api.controller.comment.dto.CommentCreateRequestDto;
+import org.prgrms.devconnect.api.controller.comment.dto.request.CommentCreateRequestDto;
+import org.prgrms.devconnect.api.controller.comment.dto.response.CommentResponseDto;
 import org.prgrms.devconnect.api.service.comment.CommentCommandService;
 import org.prgrms.devconnect.api.service.comment.CommentQueryService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
 
 @RestController
 @RequestMapping("/api/v1/comments")
@@ -23,5 +24,11 @@ public class CommentController {
   public ResponseEntity<Void> createComment(@RequestBody @Valid CommentCreateRequestDto commentCreateRequestDto) {
     commentCommandService.createComment(commentCreateRequestDto);
     return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
+
+  @GetMapping("/{boardId}")
+  public ResponseEntity<Page<CommentResponseDto>> getComments(@PathVariable Long boardId, Pageable pageable) {
+    Page<CommentResponseDto>comments= commentCommandService.getCommentsByBoardId(boardId,pageable);
+    return ResponseEntity.ok(comments);
   }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/comment/dto/request/CommentCreateRequestDto.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/comment/dto/request/CommentCreateRequestDto.java
@@ -1,4 +1,4 @@
-package org.prgrms.devconnect.api.controller.comment.dto;
+package org.prgrms.devconnect.api.controller.comment.dto.request;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;

--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/comment/dto/response/CommentResponseDto.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/comment/dto/response/CommentResponseDto.java
@@ -1,0 +1,19 @@
+package org.prgrms.devconnect.api.controller.comment.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Builder
+public record CommentResponseDto(
+        Long commentId,
+        Long memberId,
+        String author,
+        String content,
+        LocalDateTime updatedAt,
+        Long parentId
+) {
+}

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/comment/CommentCommandService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/comment/CommentCommandService.java
@@ -2,13 +2,18 @@ package org.prgrms.devconnect.api.service.comment;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.prgrms.devconnect.api.controller.comment.dto.CommentCreateRequestDto;
+import org.prgrms.devconnect.api.controller.comment.dto.request.CommentCreateRequestDto;
+import org.prgrms.devconnect.api.controller.comment.dto.response.CommentResponseDto;
 import org.prgrms.devconnect.api.service.board.BoardQueryService;
 import org.prgrms.devconnect.api.service.member.MemberQueryService;
+import org.prgrms.devconnect.common.exception.ExceptionCode;
+import org.prgrms.devconnect.common.exception.comment.CommentException;
 import org.prgrms.devconnect.domain.define.board.entity.Board;
 import org.prgrms.devconnect.domain.define.board.entity.Comment;
 import org.prgrms.devconnect.domain.define.board.repository.CommentRepository;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -27,14 +32,31 @@ public class CommentCommandService {
     Comment parentComment = null;
     if (commentCreateRequestDto.parentId() != null) {
       parentComment = commentQueryService.getCommentByIdOrThrow(commentCreateRequestDto.parentId());
+
+      //최상위 댓글은 parent필드가 null이어야함.
+      if(parentComment.getParent()!=null){
+        throw new CommentException(ExceptionCode.INVALID_PARENT_COMMENT);
+      }
     }
 
     Comment comment = commentCreateRequestDto.toEntity(member, board, parentComment);
-
-    if (parentComment != null) {
-      parentComment.addChildComment(comment);
-    }
-
     commentRepository.save(comment);
+  }
+
+  public Page<CommentResponseDto> getCommentsByBoardId(Long boardId, Pageable pageable) {
+    boardQueryService.getBoardByIdOrThrow(boardId);
+    Page<Comment> comments  =commentQueryService.findAllByBoardId(boardId,pageable);
+    return comments.map(comment-> {
+              Member member=comment.getMember();
+              Comment parent= comment.getParent();
+              return CommentResponseDto.builder()
+                      .commentId(comment.getCommentId())
+                      .memberId(member.getMemberId())
+                      .author(member.getNickname())
+                      .content(comment.getContent())
+                      .updatedAt(comment.getUpdatedAt())
+                      .parentId(parent != null ? parent.getCommentId() : null)
+                      .build();
+            });
   }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/comment/CommentCommandService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/comment/CommentCommandService.java
@@ -32,31 +32,12 @@ public class CommentCommandService {
     Comment parentComment = null;
     if (commentCreateRequestDto.parentId() != null) {
       parentComment = commentQueryService.getCommentByIdOrThrow(commentCreateRequestDto.parentId());
-
-      //최상위 댓글은 parent필드가 null이어야함.
-      if(parentComment.getParent()!=null){
+      if(!parentComment.isRootComment()){
         throw new CommentException(ExceptionCode.INVALID_PARENT_COMMENT);
       }
     }
 
     Comment comment = commentCreateRequestDto.toEntity(member, board, parentComment);
     commentRepository.save(comment);
-  }
-
-  public Page<CommentResponseDto> getCommentsByBoardId(Long boardId, Pageable pageable) {
-    boardQueryService.getBoardByIdOrThrow(boardId);
-    Page<Comment> comments  =commentQueryService.findAllByBoardId(boardId,pageable);
-    return comments.map(comment-> {
-              Member member=comment.getMember();
-              Comment parent= comment.getParent();
-              return CommentResponseDto.builder()
-                      .commentId(comment.getCommentId())
-                      .memberId(member.getMemberId())
-                      .author(member.getNickname())
-                      .content(comment.getContent())
-                      .updatedAt(comment.getUpdatedAt())
-                      .parentId(parent != null ? parent.getCommentId() : null)
-                      .build();
-            });
   }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/comment/CommentQueryService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/comment/CommentQueryService.java
@@ -1,6 +1,7 @@
 package org.prgrms.devconnect.api.service.comment;
 
 import lombok.RequiredArgsConstructor;
+import org.prgrms.devconnect.api.controller.comment.dto.response.CommentResponseDto;
 import org.prgrms.devconnect.common.exception.ExceptionCode;
 import org.prgrms.devconnect.common.exception.comment.CommentException;
 import org.prgrms.devconnect.domain.define.board.entity.Comment;
@@ -24,5 +25,10 @@ public class CommentQueryService {
 
   public Page<Comment> findAllByBoardId(Long boardId, Pageable pageable){
     return commentRepository.findAllByBoardId(boardId,pageable);
+  }
+
+  public Page<CommentResponseDto> getCommentsByBoardId(Long boardId, Pageable pageable) {
+    Page<Comment> comments=findAllByBoardId(boardId,pageable);
+    return comments.map(comment-> comment.toResponseDto());
   }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/comment/CommentQueryService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/comment/CommentQueryService.java
@@ -5,8 +5,11 @@ import org.prgrms.devconnect.common.exception.ExceptionCode;
 import org.prgrms.devconnect.common.exception.comment.CommentException;
 import org.prgrms.devconnect.domain.define.board.entity.Comment;
 import org.prgrms.devconnect.domain.define.board.repository.CommentRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 
 @Service
 @RequiredArgsConstructor
@@ -17,5 +20,9 @@ public class CommentQueryService {
   public Comment getCommentByIdOrThrow(Long commentId) {
     return commentRepository.findById(commentId)
             .orElseThrow(() -> new CommentException(ExceptionCode.NOT_FOUND_COMMENT));
+  }
+
+  public Page<Comment> findAllByBoardId(Long boardId, Pageable pageable){
+    return commentRepository.findAllByBoardId(boardId,pageable);
   }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/common/exception/ExceptionCode.java
+++ b/backend/src/main/java/org/prgrms/devconnect/common/exception/ExceptionCode.java
@@ -19,6 +19,7 @@ public enum ExceptionCode {
 
   //Comment Error
   NOT_FOUND_COMMENT(404, "존재하지 않는 댓글입니다."),
+  INVALID_PARENT_COMMENT(400, "대댓글은 최상위 댓글에만 작성할 수 있습니다."),
 
   //BugReport Error
   NOT_FOUND_BUG_REPORT(404, "존재하지 않는 버그리포트입니다."),

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/board/entity/Comment.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/board/entity/Comment.java
@@ -45,9 +45,6 @@ public class Comment extends Timestamp {
   @Column(length = 500)
   private String content;
 
-  @OneToMany(mappedBy = "parent")
-  private List<Comment> children= new ArrayList<>();
-
   @Builder
   public Comment(Member member,Board board, Comment parent,String content) {
     this.member = member;
@@ -56,8 +53,4 @@ public class Comment extends Timestamp {
     this.content = content;
   }
 
-  public void addChildComment(Comment comment){
-    children.add(comment);
-    comment.parent = this;
-  }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/board/entity/Comment.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/board/entity/Comment.java
@@ -17,6 +17,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.prgrms.devconnect.api.controller.comment.dto.response.CommentResponseDto;
 import org.prgrms.devconnect.domain.define.Timestamp;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 
@@ -52,5 +53,17 @@ public class Comment extends Timestamp {
     this.parent = parent;
     this.content = content;
   }
-
+  public boolean isRootComment(){
+    return parent == null;
+  }
+  public CommentResponseDto toResponseDto() {
+    return CommentResponseDto.builder()
+            .commentId(commentId)
+            .memberId(member.getMemberId())
+            .author(member.getNickname())
+            .content(content)
+            .updatedAt(getUpdatedAt())
+            .parentId(parent != null ? parent.getCommentId() : null)
+            .build();
+  }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/board/repository/CommentRepository.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/board/repository/CommentRepository.java
@@ -1,7 +1,13 @@
 package org.prgrms.devconnect.domain.define.board.repository;
 
 import org.prgrms.devconnect.domain.define.board.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>{
+  @Query("SELECT c FROM Comment c WHERE c.board.boardId = :boardId")
+  Page<Comment> findAllByBoardId(@Param("boardId") Long boardId, Pageable pageable);
 }

--- a/backend/src/test/java/org/prgrms/devconnect/api/service/comment/CommentCommandServiceTest.java
+++ b/backend/src/test/java/org/prgrms/devconnect/api/service/comment/CommentCommandServiceTest.java
@@ -1,0 +1,127 @@
+package org.prgrms.devconnect.api.service.comment;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.prgrms.devconnect.api.controller.comment.dto.request.CommentCreateRequestDto;
+import org.prgrms.devconnect.api.controller.comment.dto.response.CommentResponseDto;
+import org.prgrms.devconnect.api.service.board.BoardQueryService;
+import org.prgrms.devconnect.api.service.member.MemberQueryService;
+import org.prgrms.devconnect.common.exception.ExceptionCode;
+import org.prgrms.devconnect.common.exception.comment.CommentException;
+import org.prgrms.devconnect.domain.define.board.entity.Board;
+import org.prgrms.devconnect.domain.define.board.entity.Comment;
+import org.prgrms.devconnect.domain.define.board.repository.CommentRepository;
+import org.prgrms.devconnect.domain.define.fixture.CommentFixture;
+import org.prgrms.devconnect.domain.define.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CommentCommandServiceTest {
+
+  @InjectMocks
+  private CommentCommandService commentCommandService;
+
+  @Mock
+  private CommentRepository commentRepository;
+
+  @Mock
+  private MemberQueryService memberQueryService;
+
+  @Mock
+  private BoardQueryService boardQueryService;
+
+  @Mock
+  private CommentQueryService commentQueryService;
+
+
+  @Test
+  public void 댓글_생성_성공(){
+    // given
+    CommentCreateRequestDto commentCreateRequestDto=CommentFixture.createCommentCreateRequestDto();
+    Member member=mock(Member.class);
+    Board board=mock(Board.class);
+    Comment comment=mock(Comment.class);
+    when(memberQueryService.getMemberByIdOrThrow(any())).thenReturn(member);
+    when(boardQueryService.getBoardByIdOrThrow(any())).thenReturn(board);
+    doReturn(comment).when(commentRepository).save(any(Comment.class));
+
+    //when
+    commentCommandService.createComment(commentCreateRequestDto);
+
+    //then
+    verify(memberQueryService,times(1)).getMemberByIdOrThrow(any(Long.class));
+    verify(boardQueryService,times(1)).getBoardByIdOrThrow(any(Long.class));
+    verify(commentRepository, times(1)).save(any(Comment.class));
+  }
+
+  @Test
+  void 댓글_생성_실패_부모댓글이_최상위_댓글이_아님(){
+    //given
+    CommentCreateRequestDto commentCreateRequestDto=CommentFixture.createCommentCreateRequestDtoWithParentId();
+    Member member=mock(Member.class);
+    Board board=mock(Board.class);
+    Comment parentComment=mock(Comment.class);
+
+    when(memberQueryService.getMemberByIdOrThrow(any())).thenReturn(member);
+    when(boardQueryService.getBoardByIdOrThrow(any())).thenReturn(board);
+    when(commentQueryService.getCommentByIdOrThrow(any())).thenReturn(parentComment);
+    when(parentComment.getParent()).thenReturn(mock(Comment.class));
+
+    //when
+    CommentException commentException=assertThrows(CommentException.class,()->{
+            commentCommandService.createComment(commentCreateRequestDto);
+    });
+
+    //then
+    assertEquals(ExceptionCode.INVALID_PARENT_COMMENT,commentException.getExceptionCode());
+    verify(commentQueryService,times(1)).getCommentByIdOrThrow(any());
+    verify(commentRepository,never()).save(any(Comment.class));
+  }
+
+  @Test
+  void 게시물_ID로_댓글_페이징_조회_성공(){
+    //given
+    Long boardId=1L;
+    Pageable pageable=Pageable.ofSize(10);
+    Member member=mock(Member.class);
+    Comment comment=mock(Comment.class);
+    Comment parentComment=mock(Comment.class);
+
+    when(comment.getMember()).thenReturn(member);
+    when(comment.getParent()).thenReturn(parentComment);
+    when(member.getMemberId()).thenReturn(1L);
+    when(member.getNickname()).thenReturn("사용자");
+    when(comment.getCommentId()).thenReturn(1L);
+    when(comment.getContent()).thenReturn("테스트용 댓글");
+    when(comment.getUpdatedAt()).thenReturn(LocalDateTime.now());
+
+    Page<Comment> comments = new PageImpl<>(Collections.singletonList(comment), pageable, 1);
+
+    when(boardQueryService.getBoardByIdOrThrow(boardId)).thenReturn(mock(Board.class));
+    when(commentQueryService.findAllByBoardId(boardId,pageable)).thenReturn(comments);
+
+    //when
+    Page<CommentResponseDto>result=commentCommandService.getCommentsByBoardId(boardId,pageable);
+
+    //then
+    assertNotNull(result);
+    assertEquals(1, result.getTotalElements());
+    assertEquals(1L, result.getContent().get(0).commentId());
+    assertEquals("사용자", result.getContent().get(0).author());
+    assertEquals("테스트용 댓글", result.getContent().get(0).content());
+
+    verify(boardQueryService,times(1)).getBoardByIdOrThrow(boardId);
+    verify(commentQueryService,times(1)).findAllByBoardId(boardId,pageable);
+  }
+}

--- a/backend/src/test/java/org/prgrms/devconnect/api/service/comment/CommentCommandServiceTest.java
+++ b/backend/src/test/java/org/prgrms/devconnect/api/service/comment/CommentCommandServiceTest.java
@@ -60,9 +60,9 @@ public class CommentCommandServiceTest {
     commentCommandService.createComment(commentCreateRequestDto);
 
     //then
-    verify(memberQueryService,times(1)).getMemberByIdOrThrow(any(Long.class));
-    verify(boardQueryService,times(1)).getBoardByIdOrThrow(any(Long.class));
-    verify(commentRepository, times(1)).save(any(Comment.class));
+    verify(memberQueryService).getMemberByIdOrThrow(any(Long.class));
+    verify(boardQueryService).getBoardByIdOrThrow(any(Long.class));
+    verify(commentRepository).save(any(Comment.class));
   }
 
   @Test
@@ -76,7 +76,6 @@ public class CommentCommandServiceTest {
     when(memberQueryService.getMemberByIdOrThrow(any())).thenReturn(member);
     when(boardQueryService.getBoardByIdOrThrow(any())).thenReturn(board);
     when(commentQueryService.getCommentByIdOrThrow(any())).thenReturn(parentComment);
-    when(parentComment.getParent()).thenReturn(mock(Comment.class));
 
     //when
     CommentException commentException=assertThrows(CommentException.class,()->{
@@ -85,43 +84,7 @@ public class CommentCommandServiceTest {
 
     //then
     assertEquals(ExceptionCode.INVALID_PARENT_COMMENT,commentException.getExceptionCode());
-    verify(commentQueryService,times(1)).getCommentByIdOrThrow(any());
+    verify(commentQueryService).getCommentByIdOrThrow(any());
     verify(commentRepository,never()).save(any(Comment.class));
-  }
-
-  @Test
-  void 게시물_ID로_댓글_페이징_조회_성공(){
-    //given
-    Long boardId=1L;
-    Pageable pageable=Pageable.ofSize(10);
-    Member member=mock(Member.class);
-    Comment comment=mock(Comment.class);
-    Comment parentComment=mock(Comment.class);
-
-    when(comment.getMember()).thenReturn(member);
-    when(comment.getParent()).thenReturn(parentComment);
-    when(member.getMemberId()).thenReturn(1L);
-    when(member.getNickname()).thenReturn("사용자");
-    when(comment.getCommentId()).thenReturn(1L);
-    when(comment.getContent()).thenReturn("테스트용 댓글");
-    when(comment.getUpdatedAt()).thenReturn(LocalDateTime.now());
-
-    Page<Comment> comments = new PageImpl<>(Collections.singletonList(comment), pageable, 1);
-
-    when(boardQueryService.getBoardByIdOrThrow(boardId)).thenReturn(mock(Board.class));
-    when(commentQueryService.findAllByBoardId(boardId,pageable)).thenReturn(comments);
-
-    //when
-    Page<CommentResponseDto>result=commentCommandService.getCommentsByBoardId(boardId,pageable);
-
-    //then
-    assertNotNull(result);
-    assertEquals(1, result.getTotalElements());
-    assertEquals(1L, result.getContent().get(0).commentId());
-    assertEquals("사용자", result.getContent().get(0).author());
-    assertEquals("테스트용 댓글", result.getContent().get(0).content());
-
-    verify(boardQueryService,times(1)).getBoardByIdOrThrow(boardId);
-    verify(commentQueryService,times(1)).findAllByBoardId(boardId,pageable);
   }
 }

--- a/backend/src/test/java/org/prgrms/devconnect/api/service/comment/CommentQueryServiceTest.java
+++ b/backend/src/test/java/org/prgrms/devconnect/api/service/comment/CommentQueryServiceTest.java
@@ -1,0 +1,79 @@
+package org.prgrms.devconnect.api.service.comment;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.prgrms.devconnect.common.exception.ExceptionCode;
+import org.prgrms.devconnect.common.exception.comment.CommentException;
+import org.prgrms.devconnect.domain.define.board.entity.Comment;
+import org.prgrms.devconnect.domain.define.board.repository.CommentRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CommentQueryServiceTest {
+  @InjectMocks
+  private CommentQueryService commentQueryService;
+
+  @Mock
+  private CommentRepository commentRepository;
+
+  @Test
+  void 댓글ID로_댓글_조회_성공(){
+    //given
+    Long commentId = 1L;
+    Comment comment =mock(Comment.class);
+    when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+
+    //when
+    Comment result=commentQueryService.getCommentByIdOrThrow(commentId);
+
+    //then
+    assertNotNull(result);
+    verify(commentRepository,times(1)).findById(commentId);
+  }
+
+  @Test
+  void 댓글ID로_댓글_조회_실패(){
+    //given
+    Long commentId = 1L;
+    when(commentRepository.findById(commentId)).thenReturn(Optional.empty());
+
+    //when
+    CommentException exception=assertThrows(CommentException.class,()-> {
+      commentQueryService.getCommentByIdOrThrow(commentId);
+    });
+
+    assertEquals(ExceptionCode.NOT_FOUND_COMMENT, exception.getExceptionCode());
+    verify(commentRepository,times(1)).findById(commentId);
+  }
+
+  @Test
+  void 게시판ID로_댓글_페이징_조회_성공(){
+    //given
+    Long boardId=1L;
+    Pageable pageable = Pageable.ofSize(10);
+    Comment comment =mock(Comment.class);
+    Page<Comment> comments = new PageImpl<>(Collections.singletonList(comment), pageable, 1);
+    when(commentQueryService.findAllByBoardId(boardId, pageable)).thenReturn(comments);
+
+    //when
+    Page<Comment>result=commentQueryService.findAllByBoardId(boardId, pageable);
+
+    //then
+    assertNotNull(result);
+    assertEquals(1,result.getTotalElements());
+    verify(commentRepository,times(1)).findAllByBoardId(boardId, pageable);
+  }
+
+
+  }

--- a/backend/src/test/java/org/prgrms/devconnect/domain/define/fixture/CommentFixture.java
+++ b/backend/src/test/java/org/prgrms/devconnect/domain/define/fixture/CommentFixture.java
@@ -1,0 +1,22 @@
+package org.prgrms.devconnect.domain.define.fixture;
+
+import org.prgrms.devconnect.api.controller.comment.dto.request.CommentCreateRequestDto;
+
+public class CommentFixture {
+  public static CommentCreateRequestDto createCommentCreateRequestDto() {
+    return CommentCreateRequestDto.builder()
+            .memberId(1L)
+            .boardId(1L)
+            .content("어떤 프로젝트인가요?")
+            .build();
+  }
+
+  public static CommentCreateRequestDto createCommentCreateRequestDtoWithParentId() {
+    return CommentCreateRequestDto.builder()
+            .memberId(1L)
+            .boardId(1L)
+            .parentId(1L)
+            .content("어떤 프로젝트인가요?")
+            .build();
+  }
+}

--- a/backend/src/test/java/org/prgrms/devconnect/domain/define/fixture/CommentFixture.java
+++ b/backend/src/test/java/org/prgrms/devconnect/domain/define/fixture/CommentFixture.java
@@ -1,8 +1,15 @@
 package org.prgrms.devconnect.domain.define.fixture;
 
 import org.prgrms.devconnect.api.controller.comment.dto.request.CommentCreateRequestDto;
+import org.prgrms.devconnect.domain.define.board.entity.Board;
+import org.prgrms.devconnect.domain.define.board.entity.Comment;
+import org.prgrms.devconnect.domain.define.member.entity.Member;
 
 public class CommentFixture {
+  public static Comment createComment(Member member, Board board,String content){
+    return Comment.builder().board(board).content(content).member(member).build();
+  }
+
   public static CommentCreateRequestDto createCommentCreateRequestDto() {
     return CommentCreateRequestDto.builder()
             .memberId(1L)


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #64 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
댓글 조회 기능 구현했습니다. 그리고 댓글 생성 시 부모 댓글에 대한 유효성 검사하는 로직 추가했습니다. 
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. CommentCommandService 
 댓글 생성 시 부모 댓글 유효성 검사 로직 추가. 부모 댓글이 최상위 댓글이 아닌 경우 CommentException을 발생시킵니다. (현재는 최상위 댓글에만 자식 댓글을 달 수 있으며, 추후 필요 시 계층형 구조로 변경할 예정입니다.)
getCommentsByBoardId 메서드 추가:게시글 ID로 게시글에 달린 댓글을 페이징 처리하여 반환하도록 구현했습니다. 

2. CommentQueryService 
  findAllByBoardId 메서드 추가: 게시글 ID로 댓글을 페이징 처리하여 조회하는 기능 구현

3. CommentController
 게시글별 댓글 페이징 조회 API 구현

4. CommentRepository 
 findAllByBoardId 메서드 추가: 게시글 ID로 댓글을 페이징 처리하여 조회하는 JPQL 쿼리 구현

5. CommentResponseDto
댓글 조회 응답을 위한 CommentResponseDto 추가

6. 테스트 코드 구현
댓글 조회 및 생성 관련 테스트 추가

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
루트 댓글(parentId가 null인 댓글) 아래에만 대댓글을 달 수 있는 방식으로 설계했는데 다른 의견이 있으면 공유 부탁드립니다!
## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
휴일 잘 보내시고, 내일 확인 부탁드려요!