### PR TITLE
[feat] 관심 채용 공고 리스트 조회, 생성, 삭제

### DIFF
--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/board/dto/response/BoardInfoResponseDto.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/board/dto/response/BoardInfoResponseDto.java
@@ -1,5 +1,7 @@
 package org.prgrms.devconnect.api.controller.board.dto.response;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import org.prgrms.devconnect.domain.define.board.entity.Board;
@@ -7,6 +9,7 @@ import org.prgrms.devconnect.domain.define.board.entity.constant.BoardCategory;
 import org.prgrms.devconnect.domain.define.board.entity.constant.ProgressWay;
 
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record BoardInfoResponseDto(
     Long boardId,
     String title,

--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/interest/InterestController.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/interest/InterestController.java
@@ -38,6 +38,14 @@ public class InterestController {
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
+  @DeleteMapping("/boards/{memberId}/{boardId}")
+  public ResponseEntity<Void> removeInterestBoard(@PathVariable Long memberId,
+      @PathVariable Long boardId) {
+    interestCommandService.removeInterestBoard(memberId, boardId);
+
+    return ResponseEntity.noContent().build();
+  }
+
   @PostMapping("/job-posts")
   public ResponseEntity<Void> addInterestJob(
       @Valid @RequestBody InterestJobPostRequestDto requestDto) {
@@ -45,10 +53,10 @@ public class InterestController {
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
-  @DeleteMapping("/boards/{memberId}/{boardId}")
-  public ResponseEntity<Void> removeInterestBoard(@PathVariable Long memberId,
-      @PathVariable Long boardId) {
-    interestCommandService.removeInterestBoard(memberId, boardId);
+  @DeleteMapping("/job-posts/{memberId}/{jobPostId}")
+  public ResponseEntity<Void> removeInterestJobPost(@PathVariable Long memberId,
+      @PathVariable Long jobPostId) {
+    interestCommandService.removeInterestJobPost(memberId, jobPostId);
 
     return ResponseEntity.noContent().build();
   }

--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/interest/InterestController.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/interest/InterestController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.prgrms.devconnect.api.controller.board.dto.response.BoardInfoResponseDto;
 import org.prgrms.devconnect.api.controller.interest.dto.request.InterestBoardRequestDto;
+import org.prgrms.devconnect.api.controller.interest.dto.response.InterestResponseDto;
 import org.prgrms.devconnect.api.service.interest.InterestCommandService;
 import org.prgrms.devconnect.api.service.interest.InterestQueryService;
 import org.springframework.http.HttpStatus;
@@ -26,9 +27,9 @@ public class InterestController {
   private final InterestCommandService interestCommandService;
 
   @GetMapping("/{memberId}")
-  public ResponseEntity<List<BoardInfoResponseDto>> getInterestBoards(@PathVariable Long memberId) {
-    List<BoardInfoResponseDto> interestBoards = interestQueryService.getInterestBoardsByMemberId(memberId);
-    return ResponseEntity.ok(interestBoards);
+  public ResponseEntity<InterestResponseDto> getInterestBoards(@PathVariable Long memberId) {
+    InterestResponseDto responseDto = interestQueryService.getInterestsByMemberId(memberId);
+    return ResponseEntity.ok(responseDto);
   }
 
   @PostMapping("/boards")

--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/interest/InterestController.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/interest/InterestController.java
@@ -1,10 +1,9 @@
 package org.prgrms.devconnect.api.controller.interest;
 
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.prgrms.devconnect.api.controller.board.dto.response.BoardInfoResponseDto;
 import org.prgrms.devconnect.api.controller.interest.dto.request.InterestBoardRequestDto;
+import org.prgrms.devconnect.api.controller.interest.dto.request.InterestJobPostRequestDto;
 import org.prgrms.devconnect.api.controller.interest.dto.response.InterestResponseDto;
 import org.prgrms.devconnect.api.service.interest.InterestCommandService;
 import org.prgrms.devconnect.api.service.interest.InterestQueryService;
@@ -39,6 +38,13 @@ public class InterestController {
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
+  @PostMapping("/job-posts")
+  public ResponseEntity<Void> addInterestJob(
+      @Valid @RequestBody InterestJobPostRequestDto requestDto) {
+    interestCommandService.addInterestJobPost(requestDto);
+    return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
+
   @DeleteMapping("/boards/{memberId}/{boardId}")
   public ResponseEntity<Void> removeInterestBoard(@PathVariable Long memberId,
       @PathVariable Long boardId) {
@@ -46,4 +52,5 @@ public class InterestController {
 
     return ResponseEntity.noContent().build();
   }
+
 }

--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/interest/dto/request/InterestJobPostRequestDto.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/interest/dto/request/InterestJobPostRequestDto.java
@@ -1,9 +1,14 @@
 package org.prgrms.devconnect.api.controller.interest.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
 import org.prgrms.devconnect.domain.define.interest.entity.InterestJobPost;
 import org.prgrms.devconnect.domain.define.jobpost.entity.JobPost;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record InterestJobPostRequestDto(
     Long memberId,
     Long jobPostId

--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/interest/dto/request/InterestJobPostRequestDto.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/interest/dto/request/InterestJobPostRequestDto.java
@@ -1,0 +1,18 @@
+package org.prgrms.devconnect.api.controller.interest.dto.request;
+
+import org.prgrms.devconnect.domain.define.interest.entity.InterestJobPost;
+import org.prgrms.devconnect.domain.define.jobpost.entity.JobPost;
+import org.prgrms.devconnect.domain.define.member.entity.Member;
+
+public record InterestJobPostRequestDto(
+    Long memberId,
+    Long jobPostId
+) {
+
+  public InterestJobPost toEntity(Member member, JobPost jobPost) {
+    return InterestJobPost.builder()
+        .member(member)
+        .jobPost(jobPost)
+        .build();
+  }
+}

--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/interest/dto/response/InterestResponseDto.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/interest/dto/response/InterestResponseDto.java
@@ -1,0 +1,34 @@
+package org.prgrms.devconnect.api.controller.interest.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import org.prgrms.devconnect.api.controller.board.dto.response.BoardInfoResponseDto;
+import org.prgrms.devconnect.api.controller.jobpost.dto.response.JobPostInfoResponseDto;
+import org.prgrms.devconnect.domain.define.interest.entity.InterestBoard;
+import org.prgrms.devconnect.domain.define.interest.entity.InterestJobPost;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record InterestResponseDto(
+    List<BoardInfoResponseDto> interestBoards,
+    List<JobPostInfoResponseDto> interestJobPosts
+) {
+
+  public static InterestResponseDto from(List<InterestBoard> interestBoards,
+      List<InterestJobPost> interestJobPosts) {
+    return InterestResponseDto.builder()
+        .interestBoards(interestBoards.stream()
+            .map(InterestBoard::getBoard)
+            .map(BoardInfoResponseDto::from)
+            .collect(Collectors.toList()))
+        .interestJobPosts(interestJobPosts.stream()
+            .map(InterestJobPost::getJobPost)
+            .map(JobPostInfoResponseDto::from)
+            .collect(Collectors.toList()))
+        .build();
+  }
+
+}

--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/jobpost/dto/response/JobPostInfoResponseDto.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/jobpost/dto/response/JobPostInfoResponseDto.java
@@ -1,0 +1,45 @@
+package org.prgrms.devconnect.api.controller.jobpost.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import org.prgrms.devconnect.domain.define.jobpost.entity.JobPost;
+import org.prgrms.devconnect.domain.define.jobpost.entity.constant.JobType;
+import org.prgrms.devconnect.domain.define.jobpost.entity.constant.Status;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record JobPostInfoResponseDto(
+    Long jobPostId,
+    String jobPostName,
+    String companyName,
+    String companyLink,
+    LocalDateTime postDate,
+    LocalDateTime openDate,
+    LocalDateTime endDate,
+    String salary,
+    JobType jobType,
+    Status status,
+    int views,
+    int likes
+) {
+
+  public static JobPostInfoResponseDto from(JobPost jobPost) {
+    return JobPostInfoResponseDto.builder()
+        .jobPostId(jobPost.getJobPostId())
+        .jobPostName(jobPost.getJobPostName())
+        .companyName(jobPost.getCompanyName())
+        .companyLink(jobPost.getCompanyLink())
+        .postDate(jobPost.getPostDate())
+        .openDate(jobPost.getOpenDate())
+        .endDate(jobPost.getEndDate())
+        .salary(jobPost.getSalary())
+        .jobType(jobPost.getJobType())
+        .status(jobPost.getStatus())
+        .views(jobPost.getViews())
+        .likes(jobPost.getLikes())
+        .build();
+  }
+
+}

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestCommandService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestCommandService.java
@@ -2,11 +2,16 @@ package org.prgrms.devconnect.api.service.interest;
 
 import lombok.RequiredArgsConstructor;
 import org.prgrms.devconnect.api.controller.interest.dto.request.InterestBoardRequestDto;
+import org.prgrms.devconnect.api.controller.interest.dto.request.InterestJobPostRequestDto;
 import org.prgrms.devconnect.api.service.board.BoardQueryService;
+import org.prgrms.devconnect.api.service.jobpost.JobPostQueryService;
 import org.prgrms.devconnect.api.service.member.MemberQueryService;
 import org.prgrms.devconnect.domain.define.board.entity.Board;
 import org.prgrms.devconnect.domain.define.interest.entity.InterestBoard;
+import org.prgrms.devconnect.domain.define.interest.entity.InterestJobPost;
 import org.prgrms.devconnect.domain.define.interest.repository.InterestBoardRepository;
+import org.prgrms.devconnect.domain.define.interest.repository.InterestJobPostRepository;
+import org.prgrms.devconnect.domain.define.jobpost.entity.JobPost;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,8 +22,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class InterestCommandService {
 
   private final InterestBoardRepository interestBoardRepository;
+  private final InterestJobPostRepository interestJobPostRepository;
   private final MemberQueryService memberQueryService;
   private final BoardQueryService boardQueryService;
+  private final JobPostQueryService jobPostQueryService;
   private final InterestQueryService interestQueryService;
 
   public void addInterestBoard(InterestBoardRequestDto requestDto) {
@@ -36,5 +43,15 @@ public class InterestCommandService {
         memberId, boardId);
 
     interestBoardRepository.delete(interestBoard);
+  }
+
+  public void addInterestJobPost(InterestJobPostRequestDto requestDto) {
+    Member member = memberQueryService.getMemberByIdOrThrow(requestDto.memberId());
+    JobPost jobPost = jobPostQueryService.getJobPostByIdOrThrow(requestDto.jobPostId());
+
+    interestQueryService.validateDuplicatedInterestJobPost(member, jobPost);
+
+    InterestJobPost interestJobPost = requestDto.toEntity(member, jobPost);
+    interestJobPostRepository.save(interestJobPost);
   }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestCommandService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestCommandService.java
@@ -54,4 +54,12 @@ public class InterestCommandService {
     InterestJobPost interestJobPost = requestDto.toEntity(member, jobPost);
     interestJobPostRepository.save(interestJobPost);
   }
+
+  public void removeInterestJobPost(Long memberId, Long jobPostId) {
+    InterestJobPost interestJobPost = interestQueryService
+        .getInterestJobPostByMemberIdAndJobPostIdOrThrow(memberId, jobPostId);
+
+    interestJobPostRepository.delete(interestJobPost);
+
+  }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestQueryService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestQueryService.java
@@ -11,6 +11,7 @@ import org.prgrms.devconnect.domain.define.interest.entity.InterestBoard;
 import org.prgrms.devconnect.domain.define.interest.entity.InterestJobPost;
 import org.prgrms.devconnect.domain.define.interest.repository.InterestBoardRepository;
 import org.prgrms.devconnect.domain.define.interest.repository.InterestJobPostRepository;
+import org.prgrms.devconnect.domain.define.jobpost.entity.JobPost;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,6 +45,12 @@ public class InterestQueryService {
   public void validateDuplicatedInterestBoard(Member member, Board board) {
     if (interestBoardRepository.existsByMemberAndBoard(member, board)) {
       throw new InterestException(ExceptionCode.DUPLICATED_INTEREST_BOARD);
+    }
+  }
+
+  public void validateDuplicatedInterestJobPost(Member member, JobPost jobPost) {
+    if (interestJobPostRepository.existsByMemberAndJobPost(member, jobPost)) {
+      throw new InterestException(ExceptionCode.DUPLICATED_INTEREST_JOB_POST);
     }
   }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestQueryService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestQueryService.java
@@ -1,15 +1,16 @@
 package org.prgrms.devconnect.api.service.interest;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.prgrms.devconnect.api.controller.board.dto.response.BoardInfoResponseDto;
+import org.prgrms.devconnect.api.controller.interest.dto.response.InterestResponseDto;
 import org.prgrms.devconnect.api.service.member.MemberQueryService;
 import org.prgrms.devconnect.common.exception.ExceptionCode;
 import org.prgrms.devconnect.common.exception.interest.InterestException;
 import org.prgrms.devconnect.domain.define.board.entity.Board;
 import org.prgrms.devconnect.domain.define.interest.entity.InterestBoard;
+import org.prgrms.devconnect.domain.define.interest.entity.InterestJobPost;
 import org.prgrms.devconnect.domain.define.interest.repository.InterestBoardRepository;
+import org.prgrms.devconnect.domain.define.interest.repository.InterestJobPostRepository;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,16 +21,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class InterestQueryService {
 
   private final InterestBoardRepository interestBoardRepository;
+  private final InterestJobPostRepository interestJobPostRepository;
   private final MemberQueryService memberQueryService;
 
-  public List<BoardInfoResponseDto> getInterestBoardsByMemberId(Long memberId) {
+  public InterestResponseDto getInterestsByMemberId(Long memberId) {
     Member member = memberQueryService.getMemberByIdOrThrow(memberId);
     List<InterestBoard> interestBoards = interestBoardRepository.findAllByMemberWithBoard(
         member);
 
-    return interestBoards.stream().map(InterestBoard::getBoard)
-        .map(BoardInfoResponseDto::from)
-        .collect(Collectors.toList());
+    List<InterestJobPost> interestJobPosts = interestJobPostRepository.findAllByMemberWithJobPost(
+        member);
+
+    return InterestResponseDto.from(interestBoards, interestJobPosts);
   }
 
   public InterestBoard getInterestBoardByMemberIdAndBoardIdOrThrow(Long memberId, Long boardId) {

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestQueryService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestQueryService.java
@@ -42,6 +42,13 @@ public class InterestQueryService {
     );
   }
 
+  public InterestJobPost getInterestJobPostByMemberIdAndJobPostIdOrThrow(Long memberId,
+      Long jobPostId) {
+    return interestJobPostRepository.findByMemberIdAndJobPostId(memberId, jobPostId).orElseThrow(
+        () -> new InterestException(ExceptionCode.NOT_FOUND_INTEREST_JOB_POST)
+    );
+  }
+
   public void validateDuplicatedInterestBoard(Member member, Board board) {
     if (interestBoardRepository.existsByMemberAndBoard(member, board)) {
       throw new InterestException(ExceptionCode.DUPLICATED_INTEREST_BOARD);

--- a/backend/src/main/java/org/prgrms/devconnect/common/exception/ExceptionCode.java
+++ b/backend/src/main/java/org/prgrms/devconnect/common/exception/ExceptionCode.java
@@ -44,7 +44,9 @@ public enum ExceptionCode {
 
   // INTEREST ERROR
   DUPLICATED_INTEREST_BOARD(400, "이미 등록된 관심 게시글입니다."),
-  NOT_FOUND_INTEREST_BOARD(404, "존재하지 않는 관심 게시글입니다.");
+  NOT_FOUND_INTEREST_BOARD(404, "존재하지 않는 관심 게시글입니다."),
+  DUPLICATED_INTEREST_JOB_POST(400, "이미 등록된 관심 채용 공고입니다."),
+  NOT_FOUND_INTEREST_JOB_POST(404, "존재하지 않는 관심 채용 공고입니다.");
 
   private final int code;
   private final String message;

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/interest/repository/InterestJobPostRepository.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/interest/repository/InterestJobPostRepository.java
@@ -1,6 +1,7 @@
 package org.prgrms.devconnect.domain.define.interest.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.prgrms.devconnect.domain.define.interest.entity.InterestJobPost;
 import org.prgrms.devconnect.domain.define.jobpost.entity.JobPost;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
@@ -13,4 +14,8 @@ public interface InterestJobPostRepository extends JpaRepository<InterestJobPost
   List<InterestJobPost> findAllByMemberWithJobPost(Member member);
 
   boolean existsByMemberAndJobPost(Member member, JobPost jobPost);
+
+  @Query("SELECT ij FROM InterestJobPost ij WHERE ij.member.memberId = :memberId And ij.jobPost.jobPostId = :jobPostId")
+  Optional<InterestJobPost> findByMemberIdAndJobPostId(Long memberId, Long jobPostId);
+
 }

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/interest/repository/InterestJobPostRepository.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/interest/repository/InterestJobPostRepository.java
@@ -2,6 +2,7 @@ package org.prgrms.devconnect.domain.define.interest.repository;
 
 import java.util.List;
 import org.prgrms.devconnect.domain.define.interest.entity.InterestJobPost;
+import org.prgrms.devconnect.domain.define.jobpost.entity.JobPost;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,4 +11,6 @@ public interface InterestJobPostRepository extends JpaRepository<InterestJobPost
 
   @Query("SELECT ij FROM InterestJobPost ij LEFT JOIN FETCH ij.jobPost WHERE ij.member = :member")
   List<InterestJobPost> findAllByMemberWithJobPost(Member member);
+
+  boolean existsByMemberAndJobPost(Member member, JobPost jobPost);
 }

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/interest/repository/InterestJobPostRepository.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/interest/repository/InterestJobPostRepository.java
@@ -1,8 +1,13 @@
 package org.prgrms.devconnect.domain.define.interest.repository;
 
+import java.util.List;
 import org.prgrms.devconnect.domain.define.interest.entity.InterestJobPost;
+import org.prgrms.devconnect.domain.define.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface InterestJobPostRepository extends JpaRepository<InterestJobPost, Long> {
 
+  @Query("SELECT ij FROM InterestJobPost ij LEFT JOIN FETCH ij.jobPost WHERE ij.member = :member")
+  List<InterestJobPost> findAllByMemberWithJobPost(Member member);
 }

--- a/backend/src/test/java/org/prgrms/devconnect/api/service/interest/InterestQueryServiceTest.java
+++ b/backend/src/test/java/org/prgrms/devconnect/api/service/interest/InterestQueryServiceTest.java
@@ -24,6 +24,7 @@ import org.prgrms.devconnect.common.exception.member.MemberException;
 import org.prgrms.devconnect.domain.define.board.entity.Board;
 import org.prgrms.devconnect.domain.define.interest.entity.InterestBoard;
 import org.prgrms.devconnect.domain.define.interest.repository.InterestBoardRepository;
+import org.prgrms.devconnect.domain.define.interest.repository.InterestJobPostRepository;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,6 +32,9 @@ class InterestQueryServiceTest {
 
   @Mock
   private InterestBoardRepository interestBoardRepository;
+
+  @Mock
+  private InterestJobPostRepository interestJobPostRepository;
 
   @Mock
   private MemberQueryService memberQueryService;
@@ -57,10 +61,11 @@ class InterestQueryServiceTest {
     when(memberQueryService.getMemberByIdOrThrow(validMemberId)).thenReturn(member);
 
     // when
-    interestQueryService.getInterestBoardsByMemberId(validMemberId);
+    interestQueryService.getInterestsByMemberId(validMemberId);
 
     // then
     verify(interestBoardRepository, times(1)).findAllByMemberWithBoard(member);
+    verify(interestJobPostRepository, times(1)).findAllByMemberWithJobPost(member);
   }
 
   @DisplayName("유효하지않는_멤버아이디가_주어지면_에러가_발생한다")
@@ -74,9 +79,12 @@ class InterestQueryServiceTest {
     );
     // when & then
     assertThatThrownBy(
-        () -> interestQueryService.getInterestBoardsByMemberId(invalidMemberId))
+        () -> interestQueryService.getInterestsByMemberId(invalidMemberId))
         .isInstanceOf(MemberException.class)
         .hasMessage(ExceptionCode.NOT_FOUND_MEMBER.getMessage());
+
+    verify(interestBoardRepository, times(0)).findAllByMemberWithBoard(member);
+    verify(interestJobPostRepository, times(0)).findAllByMemberWithJobPost(member);
   }
 
   @DisplayName("유효한_멤버와_게시글이_주어지면_관심게시글을_반환한다")

--- a/backend/src/test/java/org/prgrms/devconnect/api/service/interest/InterestQueryServiceTest.java
+++ b/backend/src/test/java/org/prgrms/devconnect/api/service/interest/InterestQueryServiceTest.java
@@ -7,10 +7,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.prgrms.devconnect.domain.define.fixture.BoardFixture.createBoard;
 import static org.prgrms.devconnect.domain.define.fixture.InterestFixture.createInterestBoard;
+import static org.prgrms.devconnect.domain.define.fixture.InterestFixture.createInterestJobPost;
 import static org.prgrms.devconnect.domain.define.fixture.JobPostFixture.createJobPost;
 import static org.prgrms.devconnect.domain.define.fixture.MemberFixture.createMember;
 
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,6 +26,7 @@ import org.prgrms.devconnect.common.exception.interest.InterestException;
 import org.prgrms.devconnect.common.exception.member.MemberException;
 import org.prgrms.devconnect.domain.define.board.entity.Board;
 import org.prgrms.devconnect.domain.define.interest.entity.InterestBoard;
+import org.prgrms.devconnect.domain.define.interest.entity.InterestJobPost;
 import org.prgrms.devconnect.domain.define.interest.repository.InterestBoardRepository;
 import org.prgrms.devconnect.domain.define.interest.repository.InterestJobPostRepository;
 import org.prgrms.devconnect.domain.define.jobpost.entity.JobPost;
@@ -48,6 +51,7 @@ class InterestQueryServiceTest {
   private Board board;
   private JobPost jobPost;
   private InterestBoard interestBoard;
+  private InterestJobPost interestJobPost;
 
   @BeforeEach
   void setup() {
@@ -55,6 +59,7 @@ class InterestQueryServiceTest {
     board = createBoard(member);
     jobPost = createJobPost();
     interestBoard = createInterestBoard(member, board);
+    interestJobPost = createInterestJobPost(member, jobPost);
   }
 
   @DisplayName("유효한_멤버아이디가_주어지면_관심게시글을_반환한다")
@@ -172,5 +177,39 @@ class InterestQueryServiceTest {
         () -> interestQueryService.validateDuplicatedInterestJobPost(member, jobPost))
         .isInstanceOf(InterestException.class)
         .hasMessage(ExceptionCode.DUPLICATED_INTEREST_JOB_POST.getMessage());
+  }
+
+  @DisplayName("유효한_멤버와_채용공고가_주어지면_관심채용공고를_반환한다")
+  @Test
+  void 유효한_멤버와_채용공고가_주어지면_관심채용공고를_반환한다() {
+    // given
+    Long memberId = 1L;
+    Long jobPostId = 1L;
+    when(interestJobPostRepository.findByMemberIdAndJobPostId(memberId, jobPostId))
+        .thenReturn(Optional.of(interestJobPost));
+    // when
+    InterestJobPost findInterestJobPost = interestQueryService.getInterestJobPostByMemberIdAndJobPostIdOrThrow(
+        memberId, jobPostId);
+
+    // then
+    verify(interestJobPostRepository, times(1)).findByMemberIdAndJobPostId(memberId, jobPostId);
+    Assertions.assertThat(findInterestJobPost).isNotNull();
+  }
+
+  @DisplayName("관심채용공고가_존재하지않으면_에러가_발생한다")
+  @Test
+  void 관심채용공고가_존재하지않으면_에러가_발생한다() {
+    // given
+    Long memberId = 1L;
+    Long jobPostId = 1L;
+    when(interestJobPostRepository.findByMemberIdAndJobPostId(memberId, jobPostId))
+        .thenReturn(Optional.empty());
+    // when & then
+    assertThatThrownBy(
+        () -> interestQueryService.getInterestJobPostByMemberIdAndJobPostIdOrThrow(memberId,
+            jobPostId))
+        .isInstanceOf(InterestException.class)
+        .hasMessage(ExceptionCode.NOT_FOUND_INTEREST_JOB_POST.getMessage());
+
   }
 }

--- a/backend/src/test/java/org/prgrms/devconnect/api/service/interest/InterestQueryServiceTest.java
+++ b/backend/src/test/java/org/prgrms/devconnect/api/service/interest/InterestQueryServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.prgrms.devconnect.domain.define.fixture.BoardFixture.createBoard;
 import static org.prgrms.devconnect.domain.define.fixture.InterestFixture.createInterestBoard;
+import static org.prgrms.devconnect.domain.define.fixture.JobPostFixture.createJobPost;
 import static org.prgrms.devconnect.domain.define.fixture.MemberFixture.createMember;
 
 import java.util.Optional;
@@ -25,6 +26,7 @@ import org.prgrms.devconnect.domain.define.board.entity.Board;
 import org.prgrms.devconnect.domain.define.interest.entity.InterestBoard;
 import org.prgrms.devconnect.domain.define.interest.repository.InterestBoardRepository;
 import org.prgrms.devconnect.domain.define.interest.repository.InterestJobPostRepository;
+import org.prgrms.devconnect.domain.define.jobpost.entity.JobPost;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 
 @ExtendWith(MockitoExtension.class)
@@ -44,12 +46,14 @@ class InterestQueryServiceTest {
 
   private Member member;
   private Board board;
+  private JobPost jobPost;
   private InterestBoard interestBoard;
 
   @BeforeEach
   void setup() {
     member = createMember("test");
     board = createBoard(member);
+    jobPost = createJobPost();
     interestBoard = createInterestBoard(member, board);
   }
 
@@ -143,5 +147,30 @@ class InterestQueryServiceTest {
         () -> interestQueryService.validateDuplicatedInterestBoard(member, board))
         .isInstanceOf(InterestException.class)
         .hasMessage(ExceptionCode.DUPLICATED_INTEREST_BOARD.getMessage());
+  }
+
+  @DisplayName("중복_관심채용공고가_없으면_에러가_발생하지_않는다")
+  @Test
+  void 중복_관심채용공고가_없으면_에러가_발생하지_않는다() {
+    // given
+    when(interestJobPostRepository.existsByMemberAndJobPost(member, jobPost))
+        .thenReturn(false);
+    // when & then
+    assertThatCode(
+        () -> interestQueryService.validateDuplicatedInterestJobPost(member, jobPost)
+    ).doesNotThrowAnyException();
+  }
+
+  @DisplayName("중복_관심채용공고가_있으면_에러가_발생한다")
+  @Test
+  void 중복_관심채용공고가_있으면_에러가_발생한다() {
+    // given
+    when(interestJobPostRepository.existsByMemberAndJobPost(member, jobPost))
+        .thenReturn(true);
+    // when & then
+    assertThatThrownBy(
+        () -> interestQueryService.validateDuplicatedInterestJobPost(member, jobPost))
+        .isInstanceOf(InterestException.class)
+        .hasMessage(ExceptionCode.DUPLICATED_INTEREST_JOB_POST.getMessage());
   }
 }

--- a/backend/src/test/java/org/prgrms/devconnect/domain/define/fixture/InterestFixture.java
+++ b/backend/src/test/java/org/prgrms/devconnect/domain/define/fixture/InterestFixture.java
@@ -1,8 +1,11 @@
 package org.prgrms.devconnect.domain.define.fixture;
 
 import org.prgrms.devconnect.api.controller.interest.dto.request.InterestBoardRequestDto;
+import org.prgrms.devconnect.api.controller.interest.dto.request.InterestJobPostRequestDto;
 import org.prgrms.devconnect.domain.define.board.entity.Board;
 import org.prgrms.devconnect.domain.define.interest.entity.InterestBoard;
+import org.prgrms.devconnect.domain.define.interest.entity.InterestJobPost;
+import org.prgrms.devconnect.domain.define.jobpost.entity.JobPost;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 
 public class InterestFixture {
@@ -30,6 +33,30 @@ public class InterestFixture {
         .boardId(boardId)
         .build();
 
+  }
+
+  //InterestJobPost
+  public static InterestJobPost createInterestJobPost(Member member, JobPost jobPost) {
+    return InterestJobPost.builder()
+        .member(member)
+        .jobPost(jobPost)
+        .build();
+  }
+
+  //InterestJobPostRequestDto
+  public static InterestJobPostRequestDto createInterestJobPostRequestDto() {
+    return InterestJobPostRequestDto.builder()
+        .memberId(1L)
+        .jobPostId(1L)
+        .build();
+  }
+
+  public static InterestJobPostRequestDto createInterestJobPostRequestDto(Long memberId,
+      Long jobPostId) {
+    return InterestJobPostRequestDto.builder()
+        .memberId(memberId)
+        .jobPostId(jobPostId)
+        .build();
   }
 
 }

--- a/backend/src/test/java/org/prgrms/devconnect/domain/define/fixture/JobPostFixture.java
+++ b/backend/src/test/java/org/prgrms/devconnect/domain/define/fixture/JobPostFixture.java
@@ -1,0 +1,32 @@
+package org.prgrms.devconnect.domain.define.fixture;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.prgrms.devconnect.domain.define.jobpost.entity.JobPost;
+import org.prgrms.devconnect.domain.define.jobpost.entity.constant.JobType;
+import org.prgrms.devconnect.domain.define.jobpost.entity.constant.Status;
+
+public class JobPostFixture {
+
+  //JobPost
+  public static JobPost createJobPost() {
+    return JobPost.builder()
+        .postId(1L)
+        .jobPostName("임시 공고")
+        .jobPostLink("임시 링크")
+        .companyName("페이퍼컴퍼니")
+        .companyLink("임시 회사 링크")
+        .companyAddress("임시 회사 주소")
+        .postDate(LocalDateTime.now())
+        .openDate(LocalDateTime.now())
+        .endDate(LocalDateTime.now())
+        .experienceLevel("경력무관")
+        .requiredEducation("대졸")
+        .salary("임시 급여")
+        .jobType(JobType.REGULAR)
+        .status(Status.RECRUITING)
+        .jobPostTechStackMappings(List.of())
+        .build();
+  }
+
+}

--- a/backend/src/test/resources/application-test.yaml
+++ b/backend/src/test/resources/application-test.yaml
@@ -17,3 +17,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+## 사람인 api key
+api:
+  key: test


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #69 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 관심 리스트 조회
  -  게시글/채용 공고 통합 조회
- 관심 채용공고 추가
- 관심 채용공고 삭제 

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- application-test.yaml 에 사람인 API 임시값 할당
  - 테스트 깨짐 방지
- 관심 리스트 조회 기능 구현 및 테스트
- 관심 채용 공고 추가 기능 구현 및 테스트
- 관심 채용 공고 삭제 기능 구현 및 테스트  

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
