### PR TITLE
[feat] 알림 읽음 처리 로직 구현

### DIFF
--- a/backend/src/main/java/org/prgrms/devconnect/api/service/alarm/AlarmQueryService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/alarm/AlarmQueryService.java
@@ -26,6 +26,8 @@ public class AlarmQueryService {
     Member member = memberQueryService.getMemberByIdOrThrow(memberId);
     List<Alarm> alarms = alarmRepository.findAllByMember(member);
 
+    alarms.forEach(Alarm::updateAlarmStatusToRead);
+
     return AlarmsGetResponse.from(alarms);
   }
 

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/entity/Alarm.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/entity/Alarm.java
@@ -38,7 +38,7 @@ public class Alarm extends CreateTimestamp {
   private String relatedUrl;
 
   @Column(name = "is_read")
-  private boolean isRead;
+  private boolean isRead = false;
 
   @Builder
   public Alarm(Member member, String alertText, String relatedUrl, boolean isRead) {
@@ -46,5 +46,8 @@ public class Alarm extends CreateTimestamp {
     this.alertText = alertText;
     this.relatedUrl = relatedUrl;
     this.isRead = isRead;
+  }
+  public void updateAlarmStatusToRead() {
+    this.isRead = true;
   }
 }

--- a/backend/src/test/java/org/prgrms/devconnect/api/service/alarm/AlarmQueryServiceTest.java
+++ b/backend/src/test/java/org/prgrms/devconnect/api/service/alarm/AlarmQueryServiceTest.java
@@ -62,6 +62,7 @@ class AlarmQueryServiceTest {
     final AlarmsGetResponse response = alarmQueryService.getAlarmsByMemberId(member.getMemberId());
 
     //then
+    assertThat(alarms.get(0).isRead()).isEqualTo(true);
     assertThat(response.count()).isEqualTo(5);
 
     verify(member).getMemberId();
@@ -72,7 +73,7 @@ class AlarmQueryServiceTest {
   @Test
   @DisplayName("한 알림에 대하여 알림아이디와 멤베 아이디가 일치하지 않을 경우 예외 처리")
   void getAlarmByAlarmIdAndMemberIdOrThrow() {
-    doReturn(Optional.empty()).when(alarmRepository).findByAlarmIdAndMemberId(anyLong(), anyLong());
+    doReturn(Optional.empty()).when(alarmRepository).findByAlarmIdAndMemberMemberId(anyLong(), anyLong());
 
     Assertions.assertThatThrownBy(() -> alarmQueryService.getAlarmByAlarmIdAndMemberIdOrThrow(anyLong(), anyLong()))
             .isInstanceOf(AlarmException.class);


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #13 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
전체 조회 했을때, 알림을 모두 읽었다고 판단하고, 수신된 알림 상태를 모두 읽음으로 표시합니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
forEach로 각각 적용했습니다..!

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
