### PR TITLE
[feat]단일 및 전체 게시물 조회

### DIFF
--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/board/BoardController.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/board/BoardController.java
@@ -4,8 +4,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.prgrms.devconnect.api.controller.board.dto.request.BoardCreateRequestDto;
 import org.prgrms.devconnect.api.controller.board.dto.request.BoardUpdateRequestDto;
+import org.prgrms.devconnect.api.controller.board.dto.response.BoardResponseDto;
 import org.prgrms.devconnect.api.service.board.BoardCommandService;
 import org.prgrms.devconnect.api.service.board.BoardQueryService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -45,5 +48,15 @@ public class BoardController {
     return ResponseEntity.status(HttpStatus.OK).build();
   }
 
+  @GetMapping("/{boardId}")
+  public ResponseEntity<BoardResponseDto>getBoardById(@PathVariable Long boardId){
+    BoardResponseDto boardResponse = boardQueryService.getBoardById(boardId);
+    return ResponseEntity.status(HttpStatus.OK).body(boardResponse);
+  }
 
+  @GetMapping
+  public ResponseEntity<Page<BoardResponseDto>> getAllBoards(Pageable pageable){
+    Page<BoardResponseDto> boards = boardQueryService.getAllBoards(pageable);
+    return ResponseEntity.status(HttpStatus.OK).body(boards);
+  }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/board/dto/response/BoardResponseDto.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/board/dto/response/BoardResponseDto.java
@@ -1,0 +1,60 @@
+package org.prgrms.devconnect.api.controller.board.dto.response;
+
+import lombok.Builder;
+import org.prgrms.devconnect.api.controller.techstack.dto.response.TechStackResponseDto;
+import org.prgrms.devconnect.domain.define.board.entity.Board;
+import org.prgrms.devconnect.domain.define.board.entity.BoardTechStackMapping;
+import org.prgrms.devconnect.domain.define.board.entity.constant.BoardCategory;
+import org.prgrms.devconnect.domain.define.board.entity.constant.BoardStatus;
+import org.prgrms.devconnect.domain.define.board.entity.constant.ProgressWay;
+import org.prgrms.devconnect.domain.define.techstack.entity.TechStack;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+public record BoardResponseDto(
+        Long boardId,
+        Long authorId,
+        String author,
+        String title,
+        String content,
+        BoardCategory category,
+        int recruitNum,
+        ProgressWay progressWay,
+        String progressPeriod,
+        LocalDateTime endDate,
+        int likes,
+        int views,
+        LocalDateTime createdDate,
+        LocalDateTime updatedDate,
+        BoardStatus status,
+        List<TechStackResponseDto>techStacks
+) {
+  public static BoardResponseDto from(Board board) {
+    List<TechStackResponseDto> techStackDtos = board.getBoardTechStacks().stream()
+            .map(BoardTechStackMapping::getTechStack)
+            .map(TechStackResponseDto::from)
+            .collect(Collectors.toList());
+
+    return BoardResponseDto.builder()
+            .boardId(board.getBoardId())
+            .authorId(board.getMember().getMemberId())
+            .author(board.getMember().getNickname())
+            .title(board.getTitle())
+            .content(board.getContent())
+            .category(board.getCategory())
+            .recruitNum(board.getRecruitNum())
+            .progressWay(board.getProgressWay())
+            .progressPeriod(board.getProgressPeriod())
+            .endDate(board.getEndDate())
+            .likes(board.getLikes())
+            .views(board.getViews())
+            .createdDate(board.getCreatedAt())
+            .updatedDate(board.getUpdatedAt())
+            .status(board.getStatus())
+            .techStacks(techStackDtos)
+            .build();
+  }
+}

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/board/BoardQueryService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/board/BoardQueryService.java
@@ -1,11 +1,14 @@
 package org.prgrms.devconnect.api.service.board;
 
 import lombok.RequiredArgsConstructor;
+import org.prgrms.devconnect.api.controller.board.dto.response.BoardResponseDto;
 import org.prgrms.devconnect.common.exception.ExceptionCode;
 import org.prgrms.devconnect.common.exception.board.BoardException;
 import org.prgrms.devconnect.domain.define.board.entity.Board;
 import org.prgrms.devconnect.domain.define.board.entity.constant.BoardStatus;
 import org.prgrms.devconnect.domain.define.board.repository.BoardRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,12 +23,18 @@ public class BoardQueryService {
   private final BoardRepository boardRepository;
 
   public Board getBoardByIdOrThrow(Long boardId) {
-    Board board= boardRepository.findById(boardId)
+    return boardRepository.findByIdAndStatusNotDeleted(boardId)
             .orElseThrow(() -> new BoardException(ExceptionCode.NOT_FOUND_BOARD));
-    if(board.isDeleted()){
-      throw new BoardException(ExceptionCode.NOT_FOUND_BOARD);
-    }
-    return board;
+  }
+
+  public BoardResponseDto getBoardById(Long boardId){
+    Board board = getBoardByIdOrThrow(boardId);
+    return BoardResponseDto.from(board);
+  }
+
+  public Page<BoardResponseDto> getAllBoards(Pageable pageable){
+    Page<Board>boards=boardRepository.findAllWithTechStackByStatusNotDeleted(pageable);
+    return boards.map(BoardResponseDto::from);
   }
 
   public List<Board> findAllByEndDateAndStatus() {

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/board/repository/BoardRepository.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/board/repository/BoardRepository.java
@@ -3,6 +3,8 @@ package org.prgrms.devconnect.domain.define.board.repository;
 
 import org.prgrms.devconnect.domain.define.board.entity.Board;
 import org.prgrms.devconnect.domain.define.board.entity.constant.BoardStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,10 +12,18 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
   @Query("SELECT b FROM Board b WHERE b.endDate< :currentDate AND b.status=:status")
   List<Board> findAllByEndDateAndStatus(@Param("currentDate") LocalDateTime currentDate,
                                         @Param("status") BoardStatus status);
+
+  // DELETED 상태가 아닌 게시글만 조회하는 메서드
+  @Query("SELECT b FROM Board b LEFT JOIN FETCH b.boardTechStacks ts LEFT JOIN FETCH ts.techStack WHERE b.status != 'DELETED'")
+  Page<Board> findAllWithTechStackByStatusNotDeleted(Pageable pageable);
+
+  @Query("SELECT b FROM Board b WHERE b.boardId = :boardId AND b.status != 'DELETED'")
+  Optional<Board> findByIdAndStatusNotDeleted(@Param("boardId") Long boardId);
 }

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/member/repository/MemberRepository.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/member/repository/MemberRepository.java
@@ -11,7 +11,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
   Optional<Member> findByEmail(String email);
 
-  @Query("SELECT m FROM Member m left join fetch m.memberTechStacks WHERE m.memberId = :memberId")
+  @Query("SELECT m FROM Member m LEFT JOIN FETCH m.memberTechStacks mts LEFT JOIN FETCH mts.techStack WHERE m.memberId = :memberId")
   Optional<Member> findByMemberIdWithTechStack(Long memberId);
 
   boolean existsByEmail(String email);


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #74  

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
단일 및 전체 게시물 조회 API 구현
삭제된 상태의 게시물은 조회되지 않도록 처리
게시물과 관련된 기술 스택 정보를 함께 조회하는 기능 추가

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
BoardQueryService에 게시물 단일 조회 및 전체 조회 로직 추가
삭제된 게시물은 조회되지 않도록 findByIdAndStatusNotDeleted 쿼리 메서드 추가
기술 스택 정보를 함께 조회하기 위해 BoardRepository와 MemberRepository에 fetch join을 통한 쿼리 최적화
게시물 및 멤버 관련 정보와 함께 관련된 기술 스택 정보도 한 번에 조회하도록 개선

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
관심 게시물과 관련된 likes수 및 Board의 조회수를 어떻게 관리하면 좋을지 의견 부탁드립니다! 

사용자가 단일 게시물을 조회할 때마다 조회수를 1씩 증가시키는 로직을 구현하는데 궁금한 점이 생겼습니다. 
단일 게시물 조회(getBoardById()) 시 조회수를 증가하여 DB에 반영해야 하는데, BoardQueryService는 읽기 전용 서비스 클래스여서 이 로직을 구현하기에 적합하지 않습니다. 그래서 BoardCommandService에 구현하려고 보니, 이 경우엔 조회와 수정 로직을 분리해야 하는 CQRS 원칙을 위반하는 것 같습니다. 
조회수 증가 로직을 어떻게 처리하는 것이 CQRS를 위반하지 않으면서도 적절할까요?혹시 의견 있으시면 피드백 부탁드립니다!
(아직 조회수 증가는 구현하지 않았습니다)