### PR TITLE
[feat] 읽지 않은 알림 수 조회 API 구현

### DIFF
--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/alarm/AlarmController.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/alarm/AlarmController.java
@@ -39,4 +39,10 @@ public class AlarmController {
     return ResponseEntity.status(NO_CONTENT)
             .body(alarmCommandService.deleteAlarmByAlarmIdAndMemberId(alarmId, memberId));
   }
+
+  @GetMapping("/counts/{memberId}")
+  public ResponseEntity<Integer> getUnReadAlarmsCount(@PathVariable Long memberId) {
+    return ResponseEntity.status(OK)
+            .body(alarmQueryService.getUnReadAlarmsCountByMemberId(memberId));
+  }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/alarm/AlarmQueryService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/alarm/AlarmQueryService.java
@@ -37,4 +37,8 @@ public class AlarmQueryService {
             () -> new AlarmException(ExceptionCode.NOT_FOUND_ALARM)
     );
   }
+
+  public int getUnReadAlarmsCountByMemberId(Long memberId) {
+    return alarmRepository.countUnreadAlarmsByMemberId(memberId);
+  }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/repository/AlarmRepository.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/repository/AlarmRepository.java
@@ -6,9 +6,13 @@ import java.util.Optional;
 import org.prgrms.devconnect.domain.define.alarm.entity.Alarm;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
   List<Alarm> findAllByMember(Member member);
+  @Query("select count(*) from Alarm a where a.member.memberId = :memberId and a.isRead = false")
+  int countUnreadAlarmsByMemberId(@Param("memberId") Long memberId);
   void deleteAllByMemberMemberId(Long memberId);
   void deleteByAlarmIdAndMemberMemberId(Long alarmId, Long memberId);
   Optional<Alarm> findByAlarmIdAndMemberMemberId(Long alarmId, Long memberId);

--- a/backend/src/test/java/org/prgrms/devconnect/api/service/alarm/AlarmQueryServiceTest.java
+++ b/backend/src/test/java/org/prgrms/devconnect/api/service/alarm/AlarmQueryServiceTest.java
@@ -1,6 +1,7 @@
 package org.prgrms.devconnect.api.service.alarm;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
@@ -9,7 +10,6 @@ import static org.mockito.Mockito.verify;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,7 +38,7 @@ class AlarmQueryServiceTest {
   @Mock
   private Member member;
 
-  private List<Alarm> alarms(){
+  private List<Alarm> alarms() {
     List<Alarm> alarms = new ArrayList<>();
     for (int i = 0; i < 5; i++) {
       alarms.add(new Alarm(member, "알림테스트", "테스트유알엘", false));
@@ -75,7 +75,13 @@ class AlarmQueryServiceTest {
   void getAlarmByAlarmIdAndMemberIdOrThrow() {
     doReturn(Optional.empty()).when(alarmRepository).findByAlarmIdAndMemberMemberId(anyLong(), anyLong());
 
-    Assertions.assertThatThrownBy(() -> alarmQueryService.getAlarmByAlarmIdAndMemberIdOrThrow(anyLong(), anyLong()))
+    assertThatThrownBy(() -> alarmQueryService.getAlarmByAlarmIdAndMemberIdOrThrow(anyLong(), anyLong()))
             .isInstanceOf(AlarmException.class);
+  }
+
+  @Test
+  @DisplayName("읽지 않은 알림의 개수 반환")
+  void getUnReadAlarmsCount() {
+    assertThat(alarmQueryService.getUnReadAlarmsCountByMemberId(member.getMemberId())).isInstanceOf(Integer.class);
   }
 }


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #86 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
읽지 않은 알림에 대해서 조회하는 API를 구현했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
JPQL을 사용해서 쿼리를 작성했습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
해당 부분 API 명세가 따로 없어, 응답을 Integer만 내보내게 간단하게 구성했는데, 수정했으면 좋겠는 부분 편하게 의견 남겨주세요!!
