### PR TITLE
[feat] 각 알림 발생 서비스 메소드에 AOP 적용

### DIFF
--- a/backend/src/main/java/org/prgrms/devconnect/api/service/alarm/AlarmCommandService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/alarm/AlarmCommandService.java
@@ -15,7 +15,7 @@ public class AlarmCommandService {
   private final AlarmRepository alarmRepository;
   private final AlarmQueryService alarmQueryService;
 
-  public void createWelcomeAlarmWhenSignIn(Member member) {
+  public Alarm createWelcomeAlarmWhenSignIn(Member member) {
 
     //TODO: 프론트 메인페이지 url 추가
     String mainPage = "";
@@ -28,6 +28,8 @@ public class AlarmCommandService {
             .relatedUrl(mainPage)
             .build();
     alarmRepository.save(alarm);
+
+    return alarm;
   }
 
   public Void deleteAlarmByAlarmIdAndMemberId(Long alarmId, Long memberId) {

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/alarm/AlarmCommandService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/alarm/AlarmCommandService.java
@@ -3,6 +3,8 @@ package org.prgrms.devconnect.api.service.alarm;
 import lombok.RequiredArgsConstructor;
 import org.prgrms.devconnect.domain.define.alarm.entity.Alarm;
 import org.prgrms.devconnect.domain.define.alarm.repository.AlarmRepository;
+import org.prgrms.devconnect.domain.define.board.entity.Board;
+import org.prgrms.devconnect.domain.define.board.entity.Comment;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,5 +44,44 @@ public class AlarmCommandService {
     alarmQueryService.getAlarmsByMemberIdOrThrow(memberId);
     alarmRepository.deleteAllByMemberMemberId(memberId);
     return null;
+  }
+
+  public Alarm createCommentPostedMessageToBoardPoster(Comment comment) {
+
+    Board postedBoard = comment.getBoard();
+    Member boardedPoster = postedBoard.getMember();
+    Member commenter = comment.getMember();
+
+    String linkedPage = "";
+    String commentPostedMessage = boardedPoster + "님이 포스팅 한 "+ postedBoard.getTitle()+ "에 "+ commenter.getNickname() + "이 댓글을 남겼습니다!";
+
+    Alarm alarm = Alarm.builder()
+            .member(boardedPoster)
+            .alertText(commentPostedMessage)
+            .relatedUrl(linkedPage)
+            .build();
+
+    alarmRepository.save(alarm);
+
+    return alarm;
+  }
+
+  public Alarm createReplyCommentReceivedAlarmToParentCommenter(Comment comment) {
+
+    Member parentCommenter = comment.getParent().getMember();
+    Member replier = comment.getMember();
+
+    String likedPage = "";
+    String replyMessage = parentCommenter + "님이 작성한 댓글 \""+ comment.getContent() + "\"에 답글이 달렸어요!";
+
+    Alarm alarm = Alarm.builder()
+            .member(parentCommenter)
+            .alertText(replyMessage)
+            .relatedUrl(likedPage)
+            .build();
+
+    alarmRepository.save(alarm);
+
+    return alarm;
   }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/alarm/AlarmCommandService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/alarm/AlarmCommandService.java
@@ -1,10 +1,13 @@
 package org.prgrms.devconnect.api.service.alarm;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import lombok.RequiredArgsConstructor;
 import org.prgrms.devconnect.domain.define.alarm.entity.Alarm;
 import org.prgrms.devconnect.domain.define.alarm.repository.AlarmRepository;
 import org.prgrms.devconnect.domain.define.board.entity.Board;
 import org.prgrms.devconnect.domain.define.board.entity.Comment;
+import org.prgrms.devconnect.domain.define.interest.entity.InterestBoard;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -72,11 +75,29 @@ public class AlarmCommandService {
     Member replier = comment.getMember();
 
     String likedPage = "";
-    String replyMessage = parentCommenter + "님이 작성한 댓글 \""+ comment.getContent() + "\"에 답글이 달렸어요!";
+    String replyMessage = parentCommenter.getNickname() + "님이 작성한 댓글 \""+ comment.getContent() + "\"에 답글이 달렸어요!";
 
     Alarm alarm = Alarm.builder()
             .member(parentCommenter)
             .alertText(replyMessage)
+            .relatedUrl(likedPage)
+            .build();
+
+    alarmRepository.save(alarm);
+
+    return alarm;
+  }
+
+  public Alarm createUrgentAlarmAboutInterestBoard(InterestBoard interestBoard) {
+    Member member = interestBoard.getMember();
+    Board board = interestBoard.getBoard();
+    long remainingDate = LocalDate.now().until(board.getEndDate().toLocalDate(), ChronoUnit.DAYS);
+    String likedPage = "";
+    String urgentMessage = member.getNickname() + "님이 관심 표시한 " +  board.getTitle() + "의 마감 기한까지" + remainingDate + "일 남았습니다. 얼른 지원해보세요!";
+
+    Alarm alarm = Alarm.builder()
+            .member(member)
+            .alertText(urgentMessage)
             .relatedUrl(likedPage)
             .build();
 

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/comment/CommentCommandService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/comment/CommentCommandService.java
@@ -8,12 +8,11 @@ import org.prgrms.devconnect.api.service.board.BoardQueryService;
 import org.prgrms.devconnect.api.service.member.MemberQueryService;
 import org.prgrms.devconnect.common.exception.ExceptionCode;
 import org.prgrms.devconnect.common.exception.comment.CommentException;
+import org.prgrms.devconnect.domain.define.alarm.aop.RegisterPublisher;
 import org.prgrms.devconnect.domain.define.board.entity.Board;
 import org.prgrms.devconnect.domain.define.board.entity.Comment;
 import org.prgrms.devconnect.domain.define.board.repository.CommentRepository;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -25,7 +24,8 @@ public class CommentCommandService {
   private final BoardQueryService boardQueryService;
   private final CommentQueryService commentQueryService;
 
-  public void createComment(CommentCreateRequestDto commentCreateRequestDto) {
+  @RegisterPublisher
+  public Comment createComment(CommentCreateRequestDto commentCreateRequestDto) {
     Member member = memberQueryService.getMemberByIdOrThrow(commentCreateRequestDto.memberId());
     Board board = boardQueryService.getBoardByIdOrThrow(commentCreateRequestDto.boardId());
 
@@ -39,6 +39,8 @@ public class CommentCommandService {
 
     Comment comment = commentCreateRequestDto.toEntity(member, board, parentComment);
     commentRepository.save(comment);
+
+    return comment;
   }
 
   public void updateComment(Long commentId,CommentUpdateRequestDto commentUpdateRequestDto){

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestQueryService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestQueryService.java
@@ -1,11 +1,13 @@
 package org.prgrms.devconnect.api.service.interest;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.prgrms.devconnect.api.controller.interest.dto.response.InterestResponseDto;
 import org.prgrms.devconnect.api.service.member.MemberQueryService;
 import org.prgrms.devconnect.common.exception.ExceptionCode;
 import org.prgrms.devconnect.common.exception.interest.InterestException;
+import org.prgrms.devconnect.domain.define.alarm.aop.RegisterPublisher;
 import org.prgrms.devconnect.domain.define.board.entity.Board;
 import org.prgrms.devconnect.domain.define.interest.entity.InterestBoard;
 import org.prgrms.devconnect.domain.define.interest.entity.InterestJobPost;
@@ -13,6 +15,7 @@ import org.prgrms.devconnect.domain.define.interest.repository.InterestBoardRepo
 import org.prgrms.devconnect.domain.define.interest.repository.InterestJobPostRepository;
 import org.prgrms.devconnect.domain.define.jobpost.entity.JobPost;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,5 +62,14 @@ public class InterestQueryService {
     if (interestJobPostRepository.existsByMemberAndJobPost(member, jobPost)) {
       throw new InterestException(ExceptionCode.DUPLICATED_INTEREST_JOB_POST);
     }
+  }
+  @Scheduled(cron = "0 0 0 * * *")
+  @RegisterPublisher
+  public List<InterestBoard> findAllUrgentBoards() {
+    List<InterestBoard> allInterestBoards = interestBoardRepository.findAll();
+    List<InterestBoard> urgentBoards = allInterestBoards.stream()
+            .filter(InterestBoard::isUrgent)
+            .collect(Collectors.toList());
+    return urgentBoards;
   }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/aop/AlarmCreater.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/aop/AlarmCreater.java
@@ -30,8 +30,7 @@ public class AlarmCreater {
 
     if ("createComment".equals(methodName)) {
       Comment comment = (Comment) object;
-      if(comment.getParent().isRootComment())
-      {
+      if(comment.getParent().isRootComment()) {
         publisher.publishEvent(new RegisteredCommentOnBoardEvent(comment));
       }
       publisher.publishEvent(new RegisteredReplyCommentEvent(comment));

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/aop/AlarmCreater.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/aop/AlarmCreater.java
@@ -4,7 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.prgrms.devconnect.domain.define.alarm.event.RegisteredCommentOnBoardEvent;
+import org.prgrms.devconnect.domain.define.alarm.event.RegisteredReplyCommentEvent;
 import org.prgrms.devconnect.domain.define.alarm.event.RegisteredWelcomeEvent;
+import org.prgrms.devconnect.domain.define.board.entity.Comment;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -23,6 +26,15 @@ public class AlarmCreater {
 
     if ("createMember".equals(methodName)) {
       publisher.publishEvent(new RegisteredWelcomeEvent((Member) object));
+    }
+
+    if ("createComment".equals(methodName)) {
+      Comment comment = (Comment) object;
+      if(comment.getParent().isRootComment())
+      {
+        publisher.publishEvent(new RegisteredCommentOnBoardEvent(comment));
+      }
+      publisher.publishEvent(new RegisteredReplyCommentEvent(comment));
     }
     return object;
   }

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/aop/AlarmCreater.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/aop/AlarmCreater.java
@@ -19,7 +19,9 @@ public class AlarmCreater {
   @Around("@annotation(org.prgrms.devconnect.domain.define.alarm.aop.RegisterPublisher)")
   public Object processRegisterPublisherAnnotation(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
     Object object = proceedingJoinPoint.proceed();
-    if (object instanceof Member) {
+    String methodName = proceedingJoinPoint.getSignature().getName();
+
+    if ("createMember".equals(methodName)) {
       publisher.publishEvent(new RegisteredWelcomeEvent((Member) object));
     }
     return object;

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/aop/AlarmCreater.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/aop/AlarmCreater.java
@@ -1,13 +1,18 @@
 package org.prgrms.devconnect.domain.define.alarm.aop;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.prgrms.devconnect.api.controller.chatting.dto.response.MessageResponse;
 import org.prgrms.devconnect.domain.define.alarm.event.RegisteredCommentOnBoardEvent;
+import org.prgrms.devconnect.domain.define.alarm.event.RegisteredReceivedMessageEvent;
 import org.prgrms.devconnect.domain.define.alarm.event.RegisteredReplyCommentEvent;
+import org.prgrms.devconnect.domain.define.alarm.event.RegisteredUrgentEvent;
 import org.prgrms.devconnect.domain.define.alarm.event.RegisteredWelcomeEvent;
 import org.prgrms.devconnect.domain.define.board.entity.Comment;
+import org.prgrms.devconnect.domain.define.interest.entity.InterestBoard;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -21,20 +26,27 @@ public class AlarmCreater {
 
   @Around("@annotation(org.prgrms.devconnect.domain.define.alarm.aop.RegisterPublisher)")
   public Object processRegisterPublisherAnnotation(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+
     Object object = proceedingJoinPoint.proceed();
     String methodName = proceedingJoinPoint.getSignature().getName();
 
-    if ("createMember".equals(methodName)) {
-      publisher.publishEvent(new RegisteredWelcomeEvent((Member) object));
-    }
-
-    if ("createComment".equals(methodName)) {
+    // TODO: 팩토리 메서드 패턴으로 리펙토링
+    if ("sendMessage".equals(methodName)) {
+      publisher.publishEvent(new RegisteredReceivedMessageEvent((MessageResponse) object));
+    } else if ("findAllUrgentBoards".equals(methodName)) {
+      for (InterestBoard interestBoard : (List<InterestBoard>) object) {
+        publisher.publishEvent(new RegisteredUrgentEvent(interestBoard));
+      }
+    } else if ("createComment".equals(methodName)) {
       Comment comment = (Comment) object;
-      if(comment.getParent().isRootComment()) {
+      if (comment.getParent().isRootComment()) {
         publisher.publishEvent(new RegisteredCommentOnBoardEvent(comment));
       }
       publisher.publishEvent(new RegisteredReplyCommentEvent(comment));
+    } else if ("createMember".equals(methodName)) {
+      publisher.publishEvent(new RegisteredWelcomeEvent((Member) object));
     }
+
     return object;
   }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/event/EventHandler.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/event/EventHandler.java
@@ -26,4 +26,9 @@ public class EventHandler {
   public void sendRegisteredReplyCommentMessageToParentCommenter(RegisteredReplyCommentEvent event) {
     alarmService.createReplyCommentReceivedAlarmToParentCommenter(event.comment());
   }
+
+  @EventListener
+  public void sendBoardUrgentAlarm(RegisteredUrgentEvent event) {
+    alarmService.createUrgentAlarmAboutInterestBoard(event.interestBoard());
+  }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/event/EventHandler.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/event/EventHandler.java
@@ -13,8 +13,17 @@ public class EventHandler {
 
   @EventListener
   public void sendWelcomeMessage(RegisteredWelcomeEvent event) {
-    alarmService.createWelcomeAlarmWhenSignIn(event.getMember());
+    alarmService.createWelcomeAlarmWhenSignIn(event.member());
     // TODO: 이메일 전송 메서드
   }
 
+  @EventListener
+  public void sendCommentPostedOnBoardToBoardPoster(RegisteredCommentOnBoardEvent event) {
+    alarmService.createCommentPostedMessageToBoardPoster(event.comment());
+  }
+
+  @EventListener
+  public void sendRegisteredReplyCommentMessageToParentCommenter(RegisteredReplyCommentEvent event) {
+    alarmService.createReplyCommentReceivedAlarmToParentCommenter(event.comment());
+  }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/event/RegisteredCommentOnBoardEvent.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/event/RegisteredCommentOnBoardEvent.java
@@ -1,0 +1,6 @@
+package org.prgrms.devconnect.domain.define.alarm.event;
+
+import org.prgrms.devconnect.domain.define.board.entity.Comment;
+
+public record RegisteredCommentOnBoardEvent(Comment comment) {
+}

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/event/RegisteredReceivedMessageEvent.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/event/RegisteredReceivedMessageEvent.java
@@ -1,0 +1,6 @@
+package org.prgrms.devconnect.domain.define.alarm.event;
+
+import org.prgrms.devconnect.api.controller.chatting.dto.response.MessageResponse;
+
+public record RegisteredReceivedMessageEvent(MessageResponse messageResponse) {
+}

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/event/RegisteredReplyCommentEvent.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/event/RegisteredReplyCommentEvent.java
@@ -1,0 +1,4 @@
+package org.prgrms.devconnect.domain.define.alarm.event;
+
+public record RegisteredReplyCommentEvent() {
+}

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/event/RegisteredReplyCommentEvent.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/event/RegisteredReplyCommentEvent.java
@@ -1,4 +1,6 @@
 package org.prgrms.devconnect.domain.define.alarm.event;
 
-public record RegisteredReplyCommentEvent() {
+import org.prgrms.devconnect.domain.define.board.entity.Comment;
+
+public record RegisteredReplyCommentEvent(Comment comment) {
 }

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/event/RegisteredUrgentEvent.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/event/RegisteredUrgentEvent.java
@@ -1,0 +1,6 @@
+package org.prgrms.devconnect.domain.define.alarm.event;
+
+import org.prgrms.devconnect.domain.define.interest.entity.InterestBoard;
+
+public record RegisteredUrgentEvent(InterestBoard interestBoard) {
+}

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/event/RegisteredWelcomeEvent.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/alarm/event/RegisteredWelcomeEvent.java
@@ -1,14 +1,7 @@
 package org.prgrms.devconnect.domain.define.alarm.event;
 
-import lombok.Getter;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 
-@Getter
-public class RegisteredWelcomeEvent {
+public record RegisteredWelcomeEvent(Member member) {
 
-  private Member member;
-
-  public RegisteredWelcomeEvent(Member member) {
-    this.member = member;
-  }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/interest/entity/InterestBoard.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/interest/entity/InterestBoard.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,5 +40,11 @@ public class InterestBoard {
   public InterestBoard(Member member, Board board) {
     this.member = member;
     this.board = board;
+  }
+
+  public boolean isUrgent() {
+    LocalDate today = LocalDate.now();
+    LocalDate endDate = this.board.getEndDate().toLocalDate();
+    return endDate.isBefore(today.plusDays(3L));
   }
 }

--- a/backend/src/test/java/org/prgrms/devconnect/api/service/alarm/AlarmCommandServiceTest.java
+++ b/backend/src/test/java/org/prgrms/devconnect/api/service/alarm/AlarmCommandServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,7 @@ import org.prgrms.devconnect.domain.define.alarm.entity.Alarm;
 import org.prgrms.devconnect.domain.define.alarm.repository.AlarmRepository;
 import org.prgrms.devconnect.domain.define.board.entity.Board;
 import org.prgrms.devconnect.domain.define.board.entity.Comment;
+import org.prgrms.devconnect.domain.define.interest.entity.InterestBoard;
 import org.prgrms.devconnect.domain.define.member.entity.Member;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -119,10 +121,13 @@ class AlarmCommandServiceTest {
   void createReplyCommentReceivedAlarmToParentCommenter() {
     Comment parent = mock();
     Comment reply = mock();
+    Member parentMember = mock();
+    Member replyMember = mock();
 
     when(reply.getParent()).thenReturn(parent);
+    when(reply.getParent().getMember()).thenReturn(parentMember);
+    when(reply.getMember()).thenReturn(replyMember);
     when(commentCommandService.createComment(mock())).thenReturn(reply);
-    when(reply.getParent()).thenReturn(parent);
 
     Alarm alarm = alarmCommandService.createReplyCommentReceivedAlarmToParentCommenter(reply);
 
@@ -130,4 +135,19 @@ class AlarmCommandServiceTest {
   }
 
 
+  @Test
+  @DisplayName("마감 임박 알림 저장 되는지 확인")
+  void createUrgentAlarmAboutInterestBoard() {
+    InterestBoard interestBoard = mock();
+    Member member = mock();
+    Board board = mock();
+
+    when(board.getEndDate()).thenReturn(LocalDateTime.MAX);
+    when(interestBoard.getMember()).thenReturn(member);
+    when(interestBoard.getBoard()).thenReturn(board);
+
+    alarmCommandService.createUrgentAlarmAboutInterestBoard(interestBoard);
+
+    verify(alarmRepository, times(1)).save(any(Alarm.class));
+  }
 }


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #88 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
커스텀 어노테이션을 활용하여, aop를 적용하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 --> 
회원가입 했을 때, 게시물에 댓글 달렸을 때, 댓글에 답글 달렸을 때, 채팅메시지를 수신했을 때 알림이 경우에 따라 다르게 동작하게 했습니다. 


## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 --> 
aop, 코드 재사용성을 생각해보면 entity -> dto 로 변환하는 작업을 서비스딴에서 하는 것보다 컨트롤러 딴에서 하는게 적합하다고 생각이 점점 들고 있는 것 같습니다. 찾아보니 해당 형변환 작업을 "꼭 어디서 해야한다" 는 없다고 하네요. 팀원들간의 상호협의를 통해 해야한다고 합니다. 혹시 같은 고민을 하신 다른 분들의 의견은 어떠신지 궁금합니당..

dad2a160e57c6e7b234e14e294c9721cd7f902a2
그리고 메소드 명으로 이벤트를 분류해두었는데(이유 : 같은 Object에 여러 종류의 이벤트가 발생할 가능성을 염두하여 메소드 명으로 변경) 메소드 명을 하드 코딩 해야 한다는 단점이 있습니다, 혹시 다른 좋은 아이디어 있으시다면 공유 부탁드립니다..!
