### PR TITLE
[feat] 관심 게시물 및 관심 채용공고 등록/해제 시 좋아요 증가/감소 기능 추가

### DIFF
--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/board/BoardController.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/board/BoardController.java
@@ -110,8 +110,6 @@ public class BoardController {
           @ApiResponse(responseCode = "404", description = "엔티티 NOT FOUND")
   })
   public ResponseEntity<BoardResponseDto> getBoardById(@PathVariable Long boardId) {
-    // 게시물을 조회하면서 조회수 증가를 동시에 처리
-    boardCommandService.increaseViews(boardId); // 조회수 증가 호출
     BoardResponseDto boardResponse = boardQueryService.getBoardById(boardId);
     return ResponseEntity.status(HttpStatus.OK).body(boardResponse);
   }

--- a/backend/src/main/java/org/prgrms/devconnect/api/controller/jobpost/JobPostController.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/controller/jobpost/JobPostController.java
@@ -49,15 +49,6 @@ public class JobPostController {
     return ResponseEntity.ok().body(jobPost);
   }
 
-  @Operation(summary = "채용 공고 좋아요", description = "특정 채용 공고에 좋아요를 추가합니다.")
-  @ApiResponse(responseCode = "200", description = "채용 공고에 좋아요가 성공적으로 추가되었습니다.")
-  @PatchMapping("/{jobPostId}/likes")
-  public ResponseEntity<Void> JobPostLikes(@PathVariable Long jobPostId) {
-
-    jobPostCommandService.jobPostLikes(jobPostId);
-    return ResponseEntity.ok().build();
-  }
-
   // 기술 스택 name으로 공고 조회
   @GetMapping("/techstack-name/{name}")
   public ResponseEntity<Page<JobPostInfoResponseDto>> getJobPostsByTechStackName(@PathVariable String name, Pageable pageable) {

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/board/BoardCommandService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/board/BoardCommandService.java
@@ -142,8 +142,17 @@ public class BoardCommandService {
             .collect(Collectors.toList());
   }
 
-  // 조회수 증가 로직
-  public void increaseViews(Long boardId) {
-    boardRepository.incrementViews(boardId);
+  // 게시물 좋아요 증가
+  public void likeBoard(Long boardId) {
+    // 게시물 조회
+    Board board = boardQueryService.getBoardByIdOrThrow(boardId);
+    board.increaseLikes();
+  }
+
+  //게시물 좋아요 감소
+  public void unlikeBoard(Long boardId) {
+    // 게시물 조회
+    Board board = boardQueryService.getBoardByIdOrThrow(boardId);
+    board.decreaseLikes();
   }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/board/BoardQueryService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/board/BoardQueryService.java
@@ -36,8 +36,13 @@ public class BoardQueryService {
         .orElseThrow(() -> new BoardException(ExceptionCode.NOT_FOUND_BOARD));
   }
 
+  // 게시물을 조회하면서 조회수 증가도 처리
   public BoardResponseDto getBoardById(Long boardId) {
+    //게시물 조회
     Board board = getBoardByIdOrThrow(boardId);
+
+    //게시물 조회수 증가
+    board.increaseViews();
     return BoardResponseDto.from(board);
   }
 

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestCommandService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/interest/InterestCommandService.java
@@ -3,7 +3,9 @@ package org.prgrms.devconnect.api.service.interest;
 import lombok.RequiredArgsConstructor;
 import org.prgrms.devconnect.api.controller.interest.dto.request.InterestBoardRequestDto;
 import org.prgrms.devconnect.api.controller.interest.dto.request.InterestJobPostRequestDto;
+import org.prgrms.devconnect.api.service.board.BoardCommandService;
 import org.prgrms.devconnect.api.service.board.BoardQueryService;
+import org.prgrms.devconnect.api.service.jobpost.JobPostCommandService;
 import org.prgrms.devconnect.api.service.jobpost.JobPostQueryService;
 import org.prgrms.devconnect.api.service.member.MemberQueryService;
 import org.prgrms.devconnect.domain.define.board.entity.Board;
@@ -25,7 +27,9 @@ public class InterestCommandService {
   private final InterestJobPostRepository interestJobPostRepository;
   private final MemberQueryService memberQueryService;
   private final BoardQueryService boardQueryService;
+  private final BoardCommandService boardCommandService;
   private final JobPostQueryService jobPostQueryService;
+  private final JobPostCommandService jobPostCommandService;
   private final InterestQueryService interestQueryService;
 
   public void addInterestBoard(InterestBoardRequestDto requestDto, Long memberId) {
@@ -34,6 +38,9 @@ public class InterestCommandService {
 
     interestQueryService.validateDuplicatedInterestBoard(member, board);
 
+    // 좋아요 증가
+    boardCommandService.likeBoard(board.getBoardId());
+
     InterestBoard interestBoard = requestDto.toEntity(member, board);
     interestBoardRepository.save(interestBoard);
   }
@@ -41,6 +48,10 @@ public class InterestCommandService {
   public void removeInterestBoard(Long memberId, Long boardId) {
     InterestBoard interestBoard = interestQueryService.getInterestBoardByMemberIdAndBoardIdOrThrow(
         memberId, boardId);
+    Board board = boardQueryService.getBoardByIdOrThrow(boardId);
+
+    // 좋아요 감소
+    boardCommandService.unlikeBoard(board.getBoardId());
 
     interestBoardRepository.delete(interestBoard);
   }
@@ -51,6 +62,9 @@ public class InterestCommandService {
 
     interestQueryService.validateDuplicatedInterestJobPost(member, jobPost);
 
+    // 좋아요 증가
+    jobPostCommandService.likeJobPost(jobPost.getJobPostId());
+
     InterestJobPost interestJobPost = requestDto.toEntity(member, jobPost);
     interestJobPostRepository.save(interestJobPost);
   }
@@ -58,6 +72,10 @@ public class InterestCommandService {
   public void removeInterestJobPost(Long memberId, Long jobPostId) {
     InterestJobPost interestJobPost = interestQueryService
         .getInterestJobPostByMemberIdAndJobPostIdOrThrow(memberId, jobPostId);
+    JobPost jobPost = jobPostQueryService.getJobPostByIdOrThrow(jobPostId);
+
+    // 좋아요 감소
+    jobPostCommandService.unlikeJobPost(jobPost.getPostId());
 
     interestJobPostRepository.delete(interestJobPost);
 

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/jobpost/JobPostCommandService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/jobpost/JobPostCommandService.java
@@ -72,11 +72,20 @@ public class JobPostCommandService {
   }
 
   // 공고 좋아요 증가
-  public void jobPostLikes(Long jobPostId) {
+  public void likeJobPost(Long jobPostId) {
 
     // 공고 조회
     JobPost jobPost = jobPostQueryService.getJobPostByIdOrThrow(jobPostId);
 
-    jobPost.incrementLikes();
+    jobPost.increaseLikes();
+  }
+
+  // 공고 좋아요 감소
+  public void unlikeJobPost(Long jobPostId) {
+
+    // 공고 조회
+    JobPost jobPost = jobPostQueryService.getJobPostByIdOrThrow(jobPostId);
+
+    jobPost.decreaseLikes();
   }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/api/service/jobpost/JobPostQueryService.java
+++ b/backend/src/main/java/org/prgrms/devconnect/api/service/jobpost/JobPostQueryService.java
@@ -43,7 +43,7 @@ public class JobPostQueryService {
     JobPost jobPost = getJobPostByIdOrThrow(jobPostId);
 
     // 조회수 증가
-    jobPost.incrementViews();
+    jobPost.increaseViews();
     return JobPostInfoResponseDto.from(jobPost);
   }
 

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/board/entity/Board.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/board/entity/Board.java
@@ -140,4 +140,19 @@ public class Board extends Timestamp {
 
 
   }
+
+//  조회수 1 증가
+  public void increaseViews() {
+    this.views += 1;
+  }
+
+  //  좋아요수 1 증가
+  public void increaseLikes() {
+    this.likes += 1;
+  }
+
+  //  좋아요수 1 감소
+  public void decreaseLikes() {
+    this.likes -= 1;
+  }
 }

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/board/repository/BoardRepository.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/board/repository/BoardRepository.java
@@ -43,8 +43,4 @@ public interface BoardRepository extends JpaRepository<Board, Long>, BoardReposi
   List<Board> findAllByTechStacks(
           @Param("techStacks") List<TechStack> techStacks
   );
-
-  @Modifying
-  @Query("UPDATE Board b SET b.views = b.views + 1 WHERE b.boardId = :boardId")
-  void incrementViews(@Param("boardId") Long boardId);
 }

--- a/backend/src/main/java/org/prgrms/devconnect/domain/define/jobpost/entity/JobPost.java
+++ b/backend/src/main/java/org/prgrms/devconnect/domain/define/jobpost/entity/JobPost.java
@@ -112,11 +112,17 @@ public class JobPost {
   }
 
   // 조회수 1 증가
-  public void incrementViews() {
+  public void increaseViews() {
     this.views += 1;
   }
 
-  public void incrementLikes() {
+  // 좋아요수 1 증가
+  public void increaseLikes() {
     this.likes += 1;
+  }
+
+  // 좋아요수 1 감소
+  public void decreaseLikes() {
+    this.likes -= 1;
   }
 }


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #110 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 관심 게시물 및 채용 공고 등록/해제 시 좋아요 증가/감소 기능 추가

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. 관심 게시물 등록 시 `BoardCommandService`를 통해 좋아요 증가
   - `InterestCommandService`에서 게시물 등록 시 좋아요가 증가하도록 구현
2. 관심 게시물 해제 시 `BoardCommandService`를 통해 좋아요 감소
   - `InterestCommandService`에서 게시물 해제 시 좋아요가 감소하도록 구현
3. 관심 채용 공고 등록 시 `JobPostCommandService`를 통해 좋아요 증가
   - `InterestCommandService`에서 채용 공고 등록 시 좋아요가 증가하도록 구현
4. 관심 채용 공고 해제 시 `JobPostCommandService`를 통해 좋아요 감소
   - `InterestCommandService`에서 채용 공고 해제 시 좋아요가 감소하도록 구현
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
JobPostController의 좋아요 처리 로직을 삭제하고 InterestCommandService에서 처리하도록 변경했습니다!
JobPost와 Board 조회수, 좋아요 관련 처리로직 및 메소드명을 통일했습니다. 
